### PR TITLE
Add styled SEO pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About ZionBoard</title>
+    <meta name="description" content="Learn about the ZionBoard project and how it helps you create free digital ward bulletins." />
+    <link rel="canonical" href="https://zionboard.com/about" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-900 p-8">
+    <header class="max-w-3xl mx-auto text-center mb-8">
+      <h1 class="text-3xl font-bold mb-2">About ZionBoard</h1>
+      <nav class="space-x-4">
+        <a href="/" class="underline text-blue-700">Home</a>
+        <a href="/features" class="underline text-blue-700">Features</a>
+        <a href="/why-free" class="underline text-blue-700">Why It&#39;s Free</a>
+        <a href="/ward-bulletins" class="underline text-blue-700">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main class="max-w-3xl mx-auto space-y-4">
+      <p>ZionBoard began as a simple way to share digital ward bulletins. I wanted an easy tool to create, print, and share bulletins without complicated software. Everything runs in your browser, so your information stays private and secure.</p>
+      <p>The platform is completely independent from ward or stake systems. You don&#39;t need access to any membership data to get started&mdash;just create a bulletin and share it with your ward. Your QR code is permanent and will always point to the latest version of your bulletin, even if you move to a new ward.</p>
+      <p>We offer a growing set of features: reusable bulletin templates, PDF export, and public links for easy sharing. More functionality is coming, and I&#39;m happy to add what you need.</p>
+      <p>If you have suggestions or want additional features, send me an email at <a href="mailto:matthew@zionboard.com" class="underline text-blue-700">matthew@zionboard.com</a>. I would love to hear how you use ZionBoard.</p>
+    </main>
+    <footer class="text-center mt-8">
+      <p>&copy; 2025 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/public/features.html
+++ b/public/features.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZionBoard Features</title>
+    <meta name="description" content="Explore the key features of ZionBoard for creating and sharing ward bulletins." />
+    <link rel="canonical" href="https://zionboard.com/features" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-900 p-8">
+    <header class="max-w-3xl mx-auto text-center mb-8">
+      <h1 class="text-3xl font-bold mb-2">ZionBoard Features</h1>
+      <nav class="space-x-4">
+        <a href="/" class="underline text-blue-700">Home</a>
+        <a href="/about" class="underline text-blue-700">About</a>
+        <a href="/why-free" class="underline text-blue-700">Why It&#39;s Free</a>
+        <a href="/ward-bulletins" class="underline text-blue-700">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main class="max-w-3xl mx-auto space-y-4">
+      <p>ZionBoard helps you build beautiful bulletins quickly. Because it isn&#39;t connected to any ward or stake database, you can start right away and keep using the same link as long as you like. Here are a few of the things you can do:</p>
+      <ul class="list-disc ml-6 space-y-1">
+        <li>Create digital bulletins in your browser</li>
+        <li>Print PDFs for members who prefer paper</li>
+        <li>Share a public link or QR code with your ward&mdash;the QR code is yours forever</li>
+        <li>Store multiple bulletins and reuse previous templates</li>
+        <li>Duplicate bulletins to save time on weekly updates</li>
+      </ul>
+      <p>Have ideas for more features? Let me know at <a href="mailto:matthew@zionboard.com" class="underline text-blue-700">matthew@zionboard.com</a>.</p>
+    </main>
+    <footer class="text-center mt-8">
+      <p>&copy; 2025 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/public/ward-bulletins.html
+++ b/public/ward-bulletins.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Digital Ward Bulletins</title>
+    <meta name="description" content="Tips for creating and sharing digital ward bulletins using ZionBoard." />
+    <link rel="canonical" href="https://zionboard.com/ward-bulletins" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-900 p-8">
+    <header class="max-w-3xl mx-auto text-center mb-8">
+      <h1 class="text-3xl font-bold mb-2">Digital Ward Bulletins</h1>
+      <nav class="space-x-4">
+        <a href="/" class="underline text-blue-700">Home</a>
+        <a href="/about" class="underline text-blue-700">About</a>
+        <a href="/features" class="underline text-blue-700">Features</a>
+        <a href="/why-free" class="underline text-blue-700">Why It&#39;s Free</a>
+      </nav>
+    </header>
+    <main class="max-w-3xl mx-auto space-y-4">
+      <p>ZionBoard makes it simple to publish ward bulletins online. Members can scan a QR code or visit your personal link to view each week&#39;s bulletin. You can also print a PDF for those who prefer paper.</p>
+      <h2 class="text-2xl font-semibold">Copy a Sample Bulletin</h2>
+      <p>If you need a quick start, copy an existing bulletin and customize it for your ward. The built-in templates make it easy to fill in agenda items, hymns, and announcements.</p>
+      <textarea id="sample-bulletin" rows="12" cols="60" readonly class="w-full max-w-xl font-mono mt-2 border rounded p-2">Ward Name: Zion 1st Ward
+Date: July 20, 2025
+Presiding: Bishop Smith
+Conducting: Brother Johnson
+Chorister: Sister Lee
+Organist: Brother Davis
+
+Opening Hymn: 100 - Nearer, My God, to Thee
+Invocation: John Doe
+Sacrament Hymn: 169 - As Now We Take the Sacrament
+Speaker: Jane Doe
+Closing Hymn: 152 - God Be with You Till We Meet Again
+Benediction: Mary Doe
+
+Announcements:
+- Ward picnic next Saturday at 5 PM
+- Youth service project on July 25 at 3 PM</textarea>
+      <br />
+      <button id="copy-bulletin" class="mt-2 px-4 py-2 bg-blue-600 text-white rounded">Copy Bulletin</button>
+      <span id="copy-message" class="text-green-600 ml-2 hidden">Copied!</span>
+      <p class="mt-4">Email <a href="mailto:matthew@zionboard.com" class="underline text-blue-700">matthew@zionboard.com</a> for help or to request additional features.</p>
+    </main>
+    <footer class="text-center mt-8">
+      <p>&copy; 2025 ZionBoard</p>
+    </footer>
+    <script>
+      const copyBtn = document.getElementById('copy-bulletin');
+      if (copyBtn) {
+        copyBtn.addEventListener('click', () => {
+          const sample = document.getElementById('sample-bulletin');
+          const text = sample && 'value' in sample ? sample.value : '';
+          navigator.clipboard.writeText(text).then(() => {
+            const msg = document.getElementById('copy-message');
+            if (msg) {
+              msg.classList.remove('hidden');
+              setTimeout(() => {
+                msg.classList.add('hidden');
+              }, 2000);
+            }
+          });
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/public/why-free.html
+++ b/public/why-free.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Why ZionBoard is Free</title>
+    <meta name="description" content="Discover why ZionBoard is offered for free and how you can support the project." />
+    <link rel="canonical" href="https://zionboard.com/why-free" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 text-gray-900 p-8">
+    <header class="max-w-3xl mx-auto text-center mb-8">
+      <h1 class="text-3xl font-bold mb-2">Why ZionBoard is Free</h1>
+      <nav class="space-x-4">
+        <a href="/" class="underline text-blue-700">Home</a>
+        <a href="/about" class="underline text-blue-700">About</a>
+        <a href="/features" class="underline text-blue-700">Features</a>
+        <a href="/ward-bulletins" class="underline text-blue-700">Ward Bulletins</a>
+      </nav>
+    </header>
+    <main class="max-w-3xl mx-auto space-y-4">
+      <p>ZionBoard is a labor of love. I built it to simplify the way wards share announcements and sacrament meeting details. By keeping it free, anyone can create a digital bulletin without barriers.</p>
+      <p>If you like the project and want to see new features, send a message to <a href="mailto:matthew@zionboard.com" class="underline text-blue-700">matthew@zionboard.com</a>. Your feedback helps shape the future of ZionBoard.</p>
+    </main>
+    <footer class="text-center mt-8">
+      <p>&copy; 2025 ZionBoard</p>
+    </footer>
+  </body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,10 @@
 {
   "rewrites": [
+    { "source": "/about", "destination": "/about.html" },
+    { "source": "/features", "destination": "/features.html" },
+    { "source": "/why-free", "destination": "/why-free.html" },
+    { "source": "/ward-bulletins", "destination": "/ward-bulletins.html" },
+    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "functions": {
@@ -8,4 +13,4 @@
       "maxDuration": 10
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- style SEO pages with Tailwind CSS
- adjust sample bulletin date to 2025
- update footer years to 2025

## Testing
- `npm run lint` *(fails: 84 errors, 4 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d91af766c832aba8ebabc060f101f