### PR TITLE
Remove /u prefix for profile links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ export default function App() {
       <Route path="/about" element={<AboutPage />} />
       <Route path="/how-to-use" element={<HowToUsePage />} />
       <Route path="/contact" element={<ContactPage />} />
-      <Route path="/u/:slug" element={<PublicBulletinPage />} />
+      <Route path="/:slug" element={<PublicBulletinPage />} />
     </Routes>
   );
 }

--- a/src/components/QRCodeGenerator.tsx
+++ b/src/components/QRCodeGenerator.tsx
@@ -71,12 +71,12 @@ export default function QRCodeGenerator({
 
     // Generate QR code URL with proper domain
     const baseUrl = window.location.hostname === 'localhost'
-      ? 'https://mywardbulletin.com'
+      ? 'https://mwbltn.com'
       : window.location.origin;
     
-    const qrData = profileSlug 
-      ? `${baseUrl}/u/${profileSlug}`
-      : `${baseUrl}/u/your-profile-slug`;
+    const qrData = profileSlug
+      ? `${baseUrl}/${profileSlug}`
+      : `${baseUrl}/your-profile-slug`;
     
     QRCode.toCanvas(canvas, qrData, {
       width: 200,
@@ -146,9 +146,9 @@ export default function QRCodeGenerator({
 
   const getPermanentUrl = () => {
     const baseUrl = window.location.hostname === 'localhost'
-      ? 'https://mywardbulletin.com'
+      ? 'https://mwbltn.com'
       : window.location.origin;
-    return profileSlug ? `${baseUrl}/u/${profileSlug}` : '';
+    return profileSlug ? `${baseUrl}/${profileSlug}` : '';
   };
 
   const handleCopyUrl = async () => {
@@ -230,7 +230,7 @@ export default function QRCodeGenerator({
           <p className="mb-2">This QR code always shows your latest bulletin</p>
           {profileSlug && (
             <p className="font-mono text-xs break-all bg-white p-1 rounded border">
-              {window.location.origin}/u/{profileSlug}
+              {window.location.origin}/{profileSlug}
             </p>
           )}
         </div>

--- a/supabase/migrations/20250713210435_hidden_resonance.sql
+++ b/supabase/migrations/20250713210435_hidden_resonance.sql
@@ -4,7 +4,7 @@
   1. New Columns
     - `profile_slug` (text, unique, nullable)
       - Custom slug for user's permanent QR code URL
-      - Used to create URLs like /u/sunset-hills-ward
+      - Used to create URLs like /sunset-hills-ward
       - Must be unique across all users
 
   2. Security


### PR DESCRIPTION
## Summary
- simplify routing for public bulletins so slugs are at the root level
- update QR code links and copy text to match the new `/slug` structure
- tweak migration docs to reflect updated URL format

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ef2863a1c832abe88854f20dbc406