### PR TITLE
Handle timeouts while fetching latest bulletin

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -634,11 +634,18 @@ export const bulletinService = {
     if (!supabase) throw new Error('Supabase not configured');
 
     // First get the user by profile_slug and their active bulletin
-    const { data: userData, error: userError } = await supabase
-      .from('users')
-      .select('id, active_bulletin_id')
-      .eq('profile_slug', profileSlug)
-      .single();
+    let userData, userError;
+    try {
+      ({ data: userData, error: userError } = await withTimeout(
+        supabase
+          .from('users')
+          .select('id, active_bulletin_id')
+          .eq('profile_slug', profileSlug)
+          .single()
+      ));
+    } catch (timeoutError) {
+      throw timeoutError;
+    }
     
     if (userError) throw userError;
     
@@ -661,11 +668,18 @@ export const bulletinService = {
     }
     
     // Get the specific bulletin
-    const { data, error } = await supabase
-      .from('bulletins')
-      .select('*')
-      .eq('id', bulletinId)
-      .single();
+    let data, error;
+    try {
+      ({ data, error } = await withTimeout(
+        supabase
+          .from('bulletins')
+          .select('*')
+          .eq('id', bulletinId)
+          .single()
+      ));
+    } catch (timeoutError) {
+      throw timeoutError;
+    }
     
     if (error) {
       // If bulletin not found, return null instead of throwing


### PR DESCRIPTION
## Summary
- prevent hanging requests when retrieving latest bulletin
- use `withTimeout` around user and bulletin queries in `getLatestBulletinByProfileSlug`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687f1c98f7cc832aa180ae7390faf8cd