### PR TITLE
Add config checks and timeouts for Supabase API

### DIFF
--- a/api/public-bulletin.ts
+++ b/api/public-bulletin.ts
@@ -2,9 +2,26 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
-const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Supabase environment variables not configured');
+}
+
+const supabase = supabaseUrl && supabaseAnonKey ? createClient(supabaseUrl, supabaseAnonKey) : null;
+
+const withTimeout = <T>(promise: Promise<T>, timeoutMs = 10000): Promise<T> => {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('Operation timed out')), timeoutMs)
+    )
+  ]);
+};
 
 export default async function handler(req, res) {
+  if (!supabase) {
+    return res.status(500).json({ error: 'Supabase not configured' });
+  }
   res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=300');
   const { profileSlug } = req.query;
   if (!profileSlug) {
@@ -12,35 +29,41 @@ export default async function handler(req, res) {
     return;
   }
   // Get the user by profile_slug
-  const { data: userData, error: userError } = await supabase
-    .from('users')
-    .select('id, active_bulletin_id')
-    .eq('profile_slug', profileSlug)
-    .single();
+  const { data: userData, error: userError } = await withTimeout(
+    supabase
+      .from('users')
+      .select('id, active_bulletin_id')
+      .eq('profile_slug', profileSlug)
+      .single()
+  );
   if (userError || !userData) {
     res.status(404).json({ error: 'User not found' });
     return;
   }
   let bulletinId = userData.active_bulletin_id;
   if (!bulletinId) {
-    const { data: latestBulletin, error: latestError } = await supabase
-      .from('bulletins')
-      .select('id')
-      .eq('created_by', userData.id)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
+    const { data: latestBulletin, error: latestError } = await withTimeout(
+      supabase
+        .from('bulletins')
+        .select('id')
+        .eq('created_by', userData.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+    );
     if (latestError || !latestBulletin) {
       res.status(404).json({ error: 'No bulletins found' });
       return;
     }
     bulletinId = latestBulletin.id;
   }
-  const { data, error } = await supabase
-    .from('bulletins')
-    .select('*')
-    .eq('id', bulletinId)
-    .single();
+  const { data, error } = await withTimeout(
+    supabase
+      .from('bulletins')
+      .select('*')
+      .eq('id', bulletinId)
+      .single()
+  );
   if (error || !data) {
     res.status(404).json({ error: 'Bulletin not found' });
     return;


### PR DESCRIPTION
## Summary
- handle missing Supabase env vars in API handler
- wrap Supabase queries in a timeout

## Testing
- `npm test`
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f1c998010832a81ec6a52cd017aaf