### PR TITLE
Add session refresh before saving

### DIFF
--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -433,6 +433,20 @@ function EditorApp() {
       setShowAuthModal(true);
       return;
     }
+    try {
+      const { data, error } = await supabase.auth.refreshSession();
+      if (error || !data.session) {
+        console.error('Session refresh failed:', error);
+        toast.error('Session expired. Please sign in again.');
+        setShowAuthModal(true);
+        return;
+      }
+    } catch (err) {
+      console.error('Session refresh error:', err);
+      toast.error('Session expired. Please sign in again.');
+      setShowAuthModal(true);
+      return;
+    }
     setLoading(true);
     console.log('[DEBUG] Save attempt started');
     const SAVE_TIMEOUT_MS = 10000;


### PR DESCRIPTION
## Summary
- refresh Supabase auth session prior to saving bulletins
- open sign-in modal if the session refresh fails

## Testing
- `npm run lint` *(fails: cannot fix massive lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687feb7199f8832a8433e1b2629fb7e5