### PR TITLE
Add domain config and multiple link options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ VITE_SUPABASE_URL=https://your-project.supabase.co
 # They should match the VITE_ variables above.
 SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_URL=https://your-project.supabase.co
+
+# Domain configuration
+VITE_FULL_DOMAIN=mywardbulletin.com
+VITE_SHORT_DOMAIN=mwbltn.com

--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@ This project uses environment variables to configure Supabase credentials. To co
    ```
    VITE_SUPABASE_URL=https://your-project.supabase.co
    VITE_SUPABASE_ANON_KEY=your-anon-key
-   SUPABASE_URL=https://your-project.supabase.co
-   SUPABASE_ANON_KEY=your-anon-key
-   ```
+  SUPABASE_URL=https://your-project.supabase.co
+  SUPABASE_ANON_KEY=your-anon-key
+  ```
 
 3. Restart your development server or redeploy the site so the new variables take effect.
+
+In addition to the Supabase credentials, you can configure the domain names used when generating share links and QR codes. Add the following variables to your `.env` file if you want to override the defaults:
+
+```
+VITE_FULL_DOMAIN=mywardbulletin.com
+VITE_SHORT_DOMAIN=mwbltn.com
+```
 
 The `.env` file is listed in `.gitignore` to keep your credentials private. If you intend to keep the entire project private, ensure your source-control platform (such as GitHub) is configured to make the repository private as well.
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,3 @@
+export const FULL_DOMAIN = import.meta.env.VITE_FULL_DOMAIN || 'mywardbulletin.com';
+export const SHORT_DOMAIN = import.meta.env.VITE_SHORT_DOMAIN || 'mwbltn.com';
+


### PR DESCRIPTION
## Summary
- add configuration variables for full and short domains
- allow selecting short/full domain when generating QR codes
- display both full and short URL variants with copy buttons
- document new variables

## Testing
- `npm run lint` *(fails: cannot find package @eslint/js)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffc3ffdcc832aa9e3a23dab562628