### PR TITLE
Update QR code modal refresh logic

### DIFF
--- a/src/components/QRCodeGenerator.tsx
+++ b/src/components/QRCodeGenerator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useImperativeHandle, forwardRef } from 'react';
 import QRCode from 'qrcode';
 import { BulletinData } from '../types/bulletin';
 import { userService } from '../lib/supabase';
@@ -25,13 +25,17 @@ interface QRCodeGeneratorProps {
   isOpen?: boolean;
 }
 
-export default function QRCodeGenerator({ 
-  user, 
-  currentActiveBulletinId, 
-  onActiveBulletinSelect, 
+export interface QRCodeGeneratorRef {
+  loadUserProfile: () => Promise<void>;
+}
+
+const QRCodeGenerator = forwardRef<QRCodeGeneratorRef, QRCodeGeneratorProps>(function QRCodeGenerator({
+  user,
+  currentActiveBulletinId,
+  onActiveBulletinSelect,
   onProfileSlugUpdate,
   isOpen
-}: QRCodeGeneratorProps) {
+}, ref) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [profileSlug, setProfileSlug] = React.useState('');
   const [isEditing, setIsEditing] = React.useState(false);
@@ -85,6 +89,10 @@ export default function QRCodeGenerator({
       setProfileSlug(cached);
     }
   };
+
+  useImperativeHandle(ref, () => ({
+    loadUserProfile,
+  }));
 
   const generateQRCode = () => {
     const canvas = canvasRef.current;
@@ -293,3 +301,5 @@ export default function QRCodeGenerator({
     </div>
   );
 }
+
+export default QRCodeGenerator;

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -5,7 +5,7 @@ import html2canvas from 'html2canvas';
 import { supabase, isSupabaseConfigured, userService, bulletinService, robustService, retryOperation } from '../lib/supabase';
 import BulletinForm from '../components/BulletinForm';
 import BulletinPreview from '../components/BulletinPreview';
-import QRCodeGenerator from '../components/QRCodeGenerator';
+import QRCodeGenerator, { QRCodeGeneratorRef } from '../components/QRCodeGenerator';
 import AuthModal from '../components/AuthModal';
 import UserMenu from '../components/UserMenu';
 import SavedBulletinsModal from '../components/SavedBulletinsModal';
@@ -134,6 +134,7 @@ function EditorApp() {
   const [bulletinData, setBulletinData] = useState<BulletinData>(() => createBlankBulletin());
 
   const [showQRCode, setShowQRCode] = useState(false);
+  const qrCodeRef = useRef<QRCodeGeneratorRef>(null);
   const bulletinRef = useRef<HTMLDivElement>(null);
   const printPage1Ref = useRef<HTMLDivElement>(null);
   const printPage2Ref = useRef<HTMLDivElement>(null);
@@ -189,6 +190,7 @@ function EditorApp() {
             console.error('Session refresh failed:', err);
           }
         }
+        qrCodeRef.current?.loadUserProfile();
         const savedDraft = localStorage.getItem(DRAFT_KEY);
         if (savedDraft) {
           try {
@@ -954,7 +956,8 @@ function EditorApp() {
                 </button>
               </div>
               {user && isSupabaseConfigured() ? (
-                <QRCodeGenerator 
+                <QRCodeGenerator
+                  ref={qrCodeRef}
                   user={user}
                   currentActiveBulletinId={activeBulletinId}
                   onActiveBulletinSelect={handleActiveBulletinSelect}


### PR DESCRIPTION
## Summary
- expose `loadUserProfile` via a forward ref from `QRCodeGenerator`
- add ref in `EditorApp` and reload QR profile slug on tab visibility

## Testing
- `npm test`
- `npm run lint` *(fails: 66 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc3b73a4832a8d4f0eebdfa8d402