### PR TITLE
Use SPA navigation

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
 
 export default function AboutPage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const navigate = useNavigate();
   // Handler to redirect to homepage
-  const goHome = () => { window.location.href = '/'; };
+  const goHome = () => navigate('/');
   // Handler to open auth modal
   const openAuthModal = () => setShowAuthModal(true);
   return (

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
 
 export default function ContactPage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const navigate = useNavigate();
   // Handler to redirect to homepage
-  const goHome = () => { window.location.href = '/'; };
+  const goHome = () => navigate('/');
   // Handler to open auth modal
   const openAuthModal = () => setShowAuthModal(true);
   return (

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -19,6 +19,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import Logo from '../components/Logo';
 import BulletinPrintLayout from '../components/BulletinPrintLayout';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import { Link } from 'react-router-dom';
 
 
 function decodeJwtExp(token: string) {
@@ -1038,9 +1039,9 @@ function EditorApp() {
               All data is processed locally in your browser for privacy and security
             </p>
             <nav className="mt-4 space-x-4">
-              <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>
-              <a href="/how-to-use" className="text-gray-600 hover:text-gray-900">How To Use</a>
-              <a href="/contact" className="text-gray-600 hover:text-gray-900">Contact</a>
+              <Link to="/about" className="text-gray-600 hover:text-gray-900">About</Link>
+              <Link to="/how-to-use" className="text-gray-600 hover:text-gray-900">How To Use</Link>
+              <Link to="/contact" className="text-gray-600 hover:text-gray-900">Contact</Link>
             </nav>
           </div>
         </div>

--- a/src/pages/HowToUsePage.tsx
+++ b/src/pages/HowToUsePage.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
 
 export default function HowToUsePage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const navigate = useNavigate();
   // Handler to redirect to homepage
-  const goHome = () => { window.location.href = '/'; };
+  const goHome = () => navigate('/');
   // Handler to open auth modal
   const openAuthModal = () => setShowAuthModal(true);
   return (


### PR DESCRIPTION
## Summary
- swap window location logic with SPA navigation using `useNavigate`
- link to internal pages with `<Link>` components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688130a39aa4832ab0a8148331181790