### PR TITLE
Implement centralized session provider

### DIFF
--- a/src/components/SavedBulletinsModal.tsx
+++ b/src/components/SavedBulletinsModal.tsx
@@ -3,13 +3,13 @@ import { X, FileText, Calendar, Trash2, Eye, AlertCircle } from 'lucide-react';
 import { bulletinService } from '../lib/supabase';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
+import { useSession } from '../lib/SessionContext';
 
 const LAST_USER_ID = 'last_user_id';
 
 interface SavedBulletinsModalProps {
   isOpen: boolean;
   onClose: () => void;
-  user: any;
   onLoadBulletin: (bulletin: any) => void;
   onDeleteBulletin: (bulletinId: string) => void;
 }
@@ -17,12 +17,12 @@ interface SavedBulletinsModalProps {
 export default function SavedBulletinsModal({
   isOpen,
   onClose,
-  user,
   onLoadBulletin,
   onDeleteBulletin
 }: SavedBulletinsModalProps) {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const queryClient = useQueryClient();
+  const { user } = useSession();
 
   useEffect(() => {
     if (user?.id) {

--- a/src/lib/SessionContext.tsx
+++ b/src/lib/SessionContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { supabase, isSupabaseConfigured, userService } from './supabase';
+
+interface UserProfile {
+  email: string;
+  profile_slug: string | null;
+  role: string;
+  active_bulletin_id: string | null;
+}
+
+interface SessionContextValue {
+  session: Session | null;
+  user: User | null;
+  profile: UserProfile | null;
+}
+
+const SessionContext = createContext<SessionContextValue>({
+  session: null,
+  user: null,
+  profile: null,
+});
+
+export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+
+  // Restore session on mount
+  useEffect(() => {
+    if (!isSupabaseConfigured() || !supabase) return;
+
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  // Fetch profile whenever we have a valid session
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!session?.user || !supabase) {
+        setProfile(null);
+        return;
+      }
+      try {
+        const data = await userService.getUserProfile(session.user.id);
+        if (data && data.length > 0) {
+          setProfile(data[0] as UserProfile);
+        } else {
+          setProfile(null);
+        }
+      } catch {
+        setProfile(null);
+      }
+    };
+
+    loadProfile();
+  }, [session]);
+
+  return (
+    <SessionContext.Provider value={{ session, user: session?.user ?? null, profile }}>
+      {children}
+    </SessionContext.Provider>
+  );
+};
+
+export const useSession = () => useContext(SessionContext);
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SessionProvider } from './lib/SessionContext';
 
 const queryClient = new QueryClient();
 
@@ -11,7 +12,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <SessionProvider>
+          <App />
+        </SessionProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>


### PR DESCRIPTION
## Summary
- create SessionProvider to handle Supabase auth and profile fetching
- wrap the app with SessionProvider
- refactor `EditorApp` to use session context instead of local auth logic
- adapt `QRCodeGenerator` and `SavedBulletinsModal` to consume session context

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688144aa9550832a84cc61860685d945