### PR TITLE
Adjust sacrament hymn placement

### DIFF
--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -169,28 +169,7 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
             </DottedLine>
           )}
 
-          {/* Sacrament Hymn */}
-          {(data.musicProgram.sacramentHymnNumber || data.musicProgram.sacramentHymnTitle) && (
-            <div className="space-y-1">
-              <DottedLine rightAlign={data.musicProgram.sacramentHymnNumber}>
-                <span>Sacrament Hymn</span>
-              </DottedLine>
-              {(data.musicProgram.sacramentHymnNumber || data.musicProgram.sacramentHymnTitle) && (
-                <div className="text-center py-1">
-                  <p className="italic">
-                    <a
-                      href={getSongUrl(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-700 underline hover:text-blue-900"
-                    >
-                      {data.musicProgram.sacramentHymnTitle || getSongTitle(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
-                    </a>
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+          {/* Sacrament hymn will be inserted with the sacrament agenda item */}
 
 
 
@@ -226,11 +205,32 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
                 <h2 className="text-lg font-bold text-gray-900 font-sans">Bearing of Testimonies</h2>
               </div>
             ) : item.type === 'sacrament' ? (
-              <div key={item.id} className="text-center py-3">
-                <h2 className="text-lg font-bold text-gray-900 font-sans">Administration of the Sacrament</h2>
-              </div>
+              <React.Fragment key={item.id}>
+                {(data.musicProgram.sacramentHymnNumber || data.musicProgram.sacramentHymnTitle) && (
+                  <div className="space-y-1">
+                    <DottedLine rightAlign={data.musicProgram.sacramentHymnNumber}>
+                      <span>Sacrament Hymn</span>
+                    </DottedLine>
+                    <div className="text-center py-1">
+                      <p className="italic">
+                        <a
+                          href={getSongUrl(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-700 underline hover:text-blue-900"
+                        >
+                          {data.musicProgram.sacramentHymnTitle || getSongTitle(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
+                        </a>
+                      </p>
+                    </div>
+                  </div>
+                )}
+                <div className="text-center py-3">
+                  <h2 className="text-lg font-bold text-gray-900 font-sans">Administration of the Sacrament</h2>
+                </div>
+              </React.Fragment>
             ) : null
-          ))}
+         ))}
 
           {/* Closing Hymn */}
           {(data.musicProgram.closingHymnNumber || data.musicProgram.closingHymnTitle) && (
@@ -493,9 +493,30 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
               <h2 className="text-lg font-bold text-gray-900 font-sans">Bearing of Testimonies</h2>
             </div>
           ) : item.type === 'sacrament' ? (
-            <div key={item.id} className="text-center py-3">
-              <h2 className="text-lg font-bold text-gray-900 font-sans">Administration of the Sacrament</h2>
-            </div>
+            <React.Fragment key={item.id}>
+              {(data.musicProgram.sacramentHymnNumber || data.musicProgram.sacramentHymnTitle) && (
+                <div className="space-y-1">
+                  <DottedLine rightAlign={data.musicProgram.sacramentHymnNumber}>
+                    <span>Sacrament Hymn</span>
+                  </DottedLine>
+                  <div className="text-center py-1">
+                    <p className="italic">
+                      <a
+                        href={getSongUrl(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-700 underline hover:text-blue-900"
+                      >
+                        {data.musicProgram.sacramentHymnTitle || getSongTitle(data.musicProgram.sacramentHymnNumber, data.musicProgram.sacramentHymnType || 'hymn')}
+                      </a>
+                    </p>
+                  </div>
+                </div>
+              )}
+              <div className="text-center py-3">
+                <h2 className="text-lg font-bold text-gray-900 font-sans">Administration of the Sacrament</h2>
+              </div>
+            </React.Fragment>
           ) : null
         ))}
 

--- a/src/components/BulletinPrintLayout.tsx
+++ b/src/components/BulletinPrintLayout.tsx
@@ -146,19 +146,22 @@ function BulletinPrintLayout({ data, refs }: { data: any, refs?: { page1?: React
                 extra={data.musicProgram?.openingHymnTitle}
               />
               <ProgramTableRow label="Invocation" value={data.prayers?.opening} />
-              <ProgramTableRow
-                label="Sacrament Hymn"
-                value={data.musicProgram?.sacramentHymnNumber}
-                extra={data.musicProgram?.sacramentHymnTitle}
-              />
-              <tr>
-                <td colSpan={3} className="text-center font-bold text-lg py-2 print:!text-2xl print:!text-black">Administration of the Sacrament</td>
-              </tr>
               {data.agenda?.map((item: any, idx: number) => (
                 item.type === 'speaker' ? (
                   <ProgramTableRow key={idx} label={item.speakerType === 'youth' ? 'Youth Speaker' : 'Speaker'} value={item.name} />
                 ) : item.type === 'musical' ? (
                   <ProgramTableRow key={idx} label={item.label || 'Musical Number'} value={item.hymnNumber || item.songName} extra={item.hymnTitle} />
+                ) : item.type === 'sacrament' ? (
+                  <React.Fragment key={idx}>
+                    <ProgramTableRow
+                      label="Sacrament Hymn"
+                      value={data.musicProgram?.sacramentHymnNumber}
+                      extra={data.musicProgram?.sacramentHymnTitle}
+                    />
+                    <tr>
+                      <td colSpan={3} className="text-center font-bold text-lg py-2 print:!text-2xl print:!text-black">Administration of the Sacrament</td>
+                    </tr>
+                  </React.Fragment>
                 ) : null
               ))}
               <ProgramTableRow


### PR DESCRIPTION
## Summary
- ensure the sacrament hymn is rendered immediately before the sacrament agenda item
- adjust print layout to insert the sacrament hymn dynamically

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b8b88c9e4832a843dcfb4621d5e6f