### PR TITLE
Add note field for testimonies

### DIFF
--- a/src/components/BulletinForm.tsx
+++ b/src/components/BulletinForm.tsx
@@ -943,8 +943,15 @@ export default function BulletinForm({ data, onChange }: BulletinFormProps) {
             {data.agenda.map((item, idx) => (
               <div key={item.id} className="bg-gray-50 p-4 rounded-lg flex flex-wrap gap-2 items-center">
                 {item.type === 'testimony' ? (
-                  <div className="w-full flex items-center justify-center">
+                  <div className="w-full space-y-2">
                     <span className="block w-full text-center font-bold text-lg text-gray-700 py-2">Bearing of Testimonies</span>
+                    <input
+                      type="text"
+                      value={item.note || ''}
+                      onChange={e => updateAgendaItem(item.id, { note: e.target.value })}
+                      placeholder="e.g., Youth after FSY"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
                   </div>
                 ) : item.type === 'sacrament' ? (
                   <div className="w-full flex items-center justify-center">

--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -203,6 +203,7 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
             ) : item.type === 'testimony' ? (
               <div key={item.id} className="text-center py-3">
                 <h2 className="text-lg font-bold text-gray-900 font-sans">Bearing of Testimonies</h2>
+                {item.note && <p className="italic text-sm mt-1">{item.note}</p>}
               </div>
             ) : item.type === 'sacrament' ? (
               <React.Fragment key={item.id}>
@@ -491,6 +492,7 @@ export default function BulletinPreview({ data, hideTabs = false }: BulletinPrev
           ) : item.type === 'testimony' ? (
             <div key={item.id} className="text-center py-3">
               <h2 className="text-lg font-bold text-gray-900 font-sans">Bearing of Testimonies</h2>
+              {item.note && <p className="italic text-sm mt-1">{item.note}</p>}
             </div>
           ) : item.type === 'sacrament' ? (
             <React.Fragment key={item.id}>

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -67,7 +67,7 @@ export interface Speaker {
 export type AgendaItem =
   | { type: 'speaker'; id: string; name: string; speakerType: 'youth' | 'adult' }
   | { type: 'musical'; id: string; label?: string; hymnNumber?: string; hymnTitle?: string; hymnType?: SongType; songName?: string; performers?: string }
-  | { type: 'testimony'; id: string }
+  | { type: 'testimony'; id: string; note?: string }
   | { type: 'sacrament'; id: string };
 
 export interface WardLeadershipEntry {


### PR DESCRIPTION
## Summary
- add an optional `note` for `testimony` agenda items
- expose new text box when editing testimonies
- render note in bulletin preview

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ba6772cdc832ab965e63c6ac2e910