### PR TITLE
Add configurable branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ SUPABASE_URL=https://your-project.supabase.co
 # Domain configuration
 VITE_FULL_DOMAIN=mywardbulletin.com
 VITE_SHORT_DOMAIN=mwbltn.com
+
+# Branding (customize or leave empty to remove)
+VITE_APP_NAME=MyWardBulletin
+VITE_APP_TAGLINE=Ward Bulletin Creator

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # MyWardBulletin
 
+## Custom Branding and Theme
+
+You can change or remove all branding by editing the following variables in your `.env` file:
+
+```bash
+VITE_APP_NAME=MyWardBulletin
+VITE_APP_TAGLINE=Ward Bulletin Creator
+```
+
+Set either value to an empty string to omit it from the UI. Fonts and colors are defined in `tailwind.config.js` and `src/index.css`. Feel free to adjust these files to fit your preferred style.
+
 This project uses environment variables to configure Supabase credentials. To connect the application to your own Supabase project:
 
 1. Copy `.env.example` to `.env` in the project root.

--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MyWardBulletin - Free Digital Ward Bulletin Creator</title>
+    <title>%VITE_APP_NAME% - Free Digital Ward Bulletin Creator</title>
     <meta name="description" content="Create, share, and print beautiful digital ward bulletins for your LDS ward. Modern, mobile-friendly, and free." />
-    <meta name="keywords" content="ward bulletin, LDS, sacrament meeting, announcements, digital bulletin, church, MyWardBulletin, print bulletin, mobile bulletin, QR code" />
+    <meta name="keywords" content="ward bulletin, LDS, sacrament meeting, announcements, digital bulletin, church, bulletin, print bulletin, mobile bulletin, QR code" />
     <link rel="canonical" href="https://mywardbulletin.com/" />
-    <meta property="og:title" content="MyWardBulletin - Free Digital Ward Bulletin Creator" />
+    <meta property="og:title" content="%VITE_APP_NAME% - Free Digital Ward Bulletin Creator" />
     <meta property="og:description" content="Create, share, and print beautiful digital ward bulletins for your LDS ward. Modern, mobile-friendly, and free." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://mywardbulletin.com/" />
     <meta property="og:image" content="https://mywardbulletin.com/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="MyWardBulletin - Free Digital Ward Bulletin Creator" />
+    <meta name="twitter:title" content="%VITE_APP_NAME% - Free Digital Ward Bulletin Creator" />
     <meta name="twitter:description" content="Create, share, and print beautiful digital ward bulletins for your LDS ward. Modern, mobile-friendly, and free." />
     <meta name="twitter:image" content="https://mywardbulletin.com/og-image.png" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />

--- a/src/components/BulletinPrintLayout.tsx
+++ b/src/components/BulletinPrintLayout.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, useEffect } from 'react';
 import QRCode from 'qrcode';
 import { sanitizeHtml } from "../lib/sanitizeHtml";
-import { SHORT_DOMAIN, FULL_DOMAIN } from "../lib/config";
+import { SHORT_DOMAIN, FULL_DOMAIN, APP_NAME } from "../lib/config";
 
 // Function to format date from ISO format to natural format
 function formatDate(dateString: string): string {
@@ -90,9 +90,11 @@ function BulletinPrintLayout({ data, refs }: { data: any, refs?: { page1?: React
             className="mb-4"
           />
           <p className="text-xs font-semibold text-gray-600 break-all print:!text-lg print:!text-black">{qrUrl}</p>
-          <p className="mt-2 font-semibold text-xs text-gray-500 print:!text-lg print:!text-black">
-            <span className="font-semibold print:!text-black">Build your own at <span className="font-semibold print:!text-black">MyWardBulletin.com</span></span>
-          </p>
+          {APP_NAME && (
+            <p className="mt-2 font-semibold text-xs text-gray-500 print:!text-lg print:!text-black">
+              <span className="font-semibold print:!text-black">Build your own at <span className="font-semibold print:!text-black">{APP_NAME}.com</span></span>
+            </p>
+          )}
         </div>
 
         {/* Front Cover (right) */}

--- a/src/components/DynamicMetaTags.tsx
+++ b/src/components/DynamicMetaTags.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { APP_NAME } from '../lib/config';
 
 interface BulletinData {
   wardName: string;
@@ -52,7 +53,7 @@ const DynamicMetaTags: React.FC<DynamicMetaTagsProps> = ({
     if (!bulletinData || !isPublicPage) {
       // Reset to default meta tags
       updateMetaTags({
-        title: 'MyWardBulletin - Free Digital Ward Bulletin Creator',
+        title: `${APP_NAME} - Free Digital Ward Bulletin Creator`,
         description: 'Create, share, and print beautiful digital ward bulletins for your LDS ward. Modern, mobile-friendly, and free.',
         image: 'https://mywardbulletin.com/og-image.png',
         url: 'https://mywardbulletin.com/'

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Logo from './Logo';
 import UserMenu from './UserMenu';
 import { Plus, Download, QrCode, LogIn, Menu, X } from 'lucide-react';
+import { APP_NAME, APP_TAGLINE } from '../lib/config';
 
 export default function Header({
   user,
@@ -30,10 +31,16 @@ export default function Header({
         <div className="flex items-center justify-between">
           <a href="/" className="flex items-center space-x-3 group focus:outline-none focus:ring-2 focus:ring-blue-500 rounded transition-shadow no-underline" style={{ textDecoration: 'none' }}>
             <Logo size={40} />
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900">MyWardBulletin</h1>
-              <p className="text-sm text-gray-600">Ward Bulletin Creator</p>
-            </div>
+            {(APP_NAME || APP_TAGLINE) && (
+              <div>
+                {APP_NAME && (
+                  <h1 className="text-3xl font-bold text-gray-900">{APP_NAME}</h1>
+                )}
+                {APP_TAGLINE && (
+                  <p className="text-sm text-gray-600">{APP_TAGLINE}</p>
+                )}
+              </div>
+            )}
           </a>
           {/* Desktop Menu */}
           <div className="hidden lg:flex items-center space-x-3">

--- a/src/components/PublicBulletinView.tsx
+++ b/src/components/PublicBulletinView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowLeft, Home } from 'lucide-react';
 import BulletinPreview from './BulletinPreview';
 import { BulletinData } from '../types/bulletin';
+import { APP_NAME } from '../lib/config';
 
 interface PublicBulletinViewProps {
   bulletinData: BulletinData | null;
@@ -74,10 +75,12 @@ export default function PublicBulletinView({
             
             {/* Help Text */}
             <div className="mt-6 pt-6 border-t border-gray-200">
-              <p className="text-xs text-gray-500">
-                Need help? Contact your ward bulletin specialist or visit{' '}
-                <a href="/contact" className="text-blue-600 hover:underline">MyWardBulletin.com</a>
-              </p>
+              {APP_NAME && (
+                <p className="text-xs text-gray-500">
+                  Need help? Contact your ward bulletin specialist or visit{' '}
+                  <a href="/contact" className="text-blue-600 hover:underline">{APP_NAME}.com</a>
+                </p>
+              )}
             </div>
           </div>
         </div>
@@ -132,10 +135,12 @@ export default function PublicBulletinView({
             
             {/* Help Text */}
             <div className="mt-6 pt-6 border-t border-gray-200">
-              <p className="text-xs text-gray-500">
-                Want to create bulletins for your ward? Visit{' '}
-                <a href="/" className="text-blue-600 hover:underline">MyWardBulletin.com</a>
-              </p>
+              {APP_NAME && (
+                <p className="text-xs text-gray-500">
+                  Want to create bulletins for your ward? Visit{' '}
+                  <a href="/" className="text-blue-600 hover:underline">{APP_NAME}.com</a>
+                </p>
+              )}
             </div>
           </div>
         </div>
@@ -150,17 +155,17 @@ export default function PublicBulletinView({
         <BulletinPreview data={bulletinData} />
         
         {/* Footer */}
-        <div className="text-center mt-8">
-          <p className="text-gray-600 text-sm">
-            Built with MyWardBulletin.com
-          </p>
-          <button
-            onClick={onBackToEditor}
-            className="mt-2 text-blue-600 hover:text-blue-700 text-sm underline"
-          >
-            Create your own bulletin
-          </button>
-        </div>
+        {APP_NAME && (
+          <div className="text-center mt-8">
+            <p className="text-gray-600 text-sm">Built with {APP_NAME}.com</p>
+            <button
+              onClick={onBackToEditor}
+              className="mt-2 text-blue-600 hover:text-blue-700 text-sm underline"
+            >
+              Create your own bulletin
+            </button>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,3 +1,5 @@
 export const FULL_DOMAIN = import.meta.env.VITE_FULL_DOMAIN || 'mywardbulletin.com';
 export const SHORT_DOMAIN = import.meta.env.VITE_SHORT_DOMAIN || 'mwbltn.com';
+export const APP_NAME = import.meta.env.VITE_APP_NAME || 'MyWardBulletin';
+export const APP_TAGLINE = import.meta.env.VITE_APP_TAGLINE || 'Ward Bulletin Creator';
 

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
+import { APP_NAME, APP_TAGLINE } from '../lib/config';
 
 export default function AboutPage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -41,9 +42,9 @@ export default function AboutPage() {
 
       <main className="max-w-3xl mx-auto px-4 py-12">
         <div className="bg-white rounded-xl shadow-lg p-8 max-w-2xl mx-auto mt-8">
-          <h1 className="text-4xl font-bold mb-4 text-blue-800">About MyWardBulletin</h1>
+          <h1 className="text-4xl font-bold mb-4 text-blue-800">About {APP_NAME}</h1>
           <p className="mb-4 text-lg text-gray-700">
-            MyWardBulletin is a free, private, and modern tool built specifically for Latter-day Saint wards and branches. It simplifies how Sunday programs and announcements are created, shared, and printed.
+            {APP_NAME} is a free, private, and modern tool built specifically for Latter-day Saint wards and branches. It simplifies how Sunday programs and announcements are created, shared, and printed.
           </p>
           <p className="mb-4 text-gray-700">
             I originally built this for my wife when she was called as the ward bulletin specialist. The tools out there were either too clunky, too rigid, or over-engineered. She just needed something that was simple, flexible, and worked every week.
@@ -82,9 +83,12 @@ export default function AboutPage() {
       <footer className="bg-white border-t border-gray-200 mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="text-center">
-            <p className="text-gray-600 text-base font-medium">
-              MyWardBulletin.com — Free Ward Bulletin Creator
-            </p>
+            {(APP_NAME || APP_TAGLINE) && (
+              <p className="text-gray-600 text-base font-medium">
+                {APP_NAME}
+                {APP_TAGLINE ? ` — ${APP_TAGLINE}` : ''}
+              </p>
+            )}
             <nav className="mt-4 space-x-4">
               <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>
               <a href="/how-to-use" className="text-gray-600 hover:text-gray-900">How To Use</a>

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
+import { APP_NAME, APP_TAGLINE } from '../lib/config';
 
 export default function ContactPage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -54,7 +55,7 @@ export default function ContactPage() {
           </p>
           <h2 className="text-xl font-bold mt-6 mb-2 text-blue-700">💡 Feedback or Feature Requests</h2>
           <p className="mb-4 text-gray-700">
-          If there's something you'd like the tool to do, or something that's confusing, feel free to send it my way. MyWardBulletin is constantly improving based on real user input.
+          If there's something you'd like the tool to do, or something that's confusing, feel free to send it my way. {APP_NAME} is constantly improving based on real user input.
           </p>
           <h2 className="text-xl font-bold mt-6 mb-2 text-blue-700">🙏 Built with Purpose</h2>
           <p className="mb-4 text-gray-700">
@@ -69,9 +70,12 @@ export default function ContactPage() {
       <footer className="bg-white border-t border-gray-200 mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="text-center">
-            <p className="text-gray-600">
-              MyWardBulletin.com - Free Ward Bulletin Creator
-            </p>
+            {(APP_NAME || APP_TAGLINE) && (
+              <p className="text-gray-600">
+                {APP_NAME}
+                {APP_TAGLINE ? ` - ${APP_TAGLINE}` : ''}
+              </p>
+            )}
             <nav className="mt-4 space-x-4">
               <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>
               <a href="/how-to-use" className="text-gray-600 hover:text-gray-900">How To Use</a>

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -18,6 +18,7 @@ import { BulletinData } from '../types/bulletin';
 import templateService, { Template } from '../lib/templateService';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import { APP_NAME, APP_TAGLINE } from '../lib/config';
 import Logo from '../components/Logo';
 import BulletinPrintLayout from '../components/BulletinPrintLayout';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
@@ -802,10 +803,16 @@ function EditorApp() {
           <div className="flex items-center justify-between">
             <a href="/" className="flex items-center space-x-3 group focus:outline-none focus:ring-2 focus:ring-blue-500 rounded transition-shadow no-underline" style={{ textDecoration: 'none' }}>
               <Logo size={40} />
-              <div>
-                <h1 className="text-3xl font-bold text-gray-900">MyWardBulletin</h1>
-                <p className="text-sm text-gray-600">Ward Bulletin Creator</p>
-              </div>
+              {(APP_NAME || APP_TAGLINE) && (
+                <div>
+                  {APP_NAME && (
+                    <h1 className="text-3xl font-bold text-gray-900">{APP_NAME}</h1>
+                  )}
+                  {APP_TAGLINE && (
+                    <p className="text-sm text-gray-600">{APP_TAGLINE}</p>
+                  )}
+                </div>
+              )}
             </a>
             {/* Desktop/Menu/Sign In button remains outside the clickable logo area */}
             
@@ -1206,9 +1213,12 @@ function EditorApp() {
       <footer className="bg-white border-t border-gray-200 mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="text-center">
-            <p className="text-gray-600">
-              MyWardBulletin.com - Free Ward Bulletin Creator
-            </p>
+            {(APP_NAME || APP_TAGLINE) && (
+              <p className="text-gray-600">
+                {APP_NAME}
+                {APP_TAGLINE ? ` - ${APP_TAGLINE}` : ''}
+              </p>
+            )}
 
             <nav className="mt-4 space-x-4">
               <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>

--- a/src/pages/HowToUsePage.tsx
+++ b/src/pages/HowToUsePage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import Header from '../components/Header';
 import AuthModal from '../components/AuthModal';
+import { APP_NAME, APP_TAGLINE } from '../lib/config';
 
 export default function HowToUsePage() {
   const [showAuthModal, setShowAuthModal] = useState(false);
@@ -39,9 +40,9 @@ export default function HowToUsePage() {
       />
       <main className="max-w-3xl mx-auto px-4 py-10">
         <div className="bg-white rounded-xl shadow-lg p-8 max-w-2xl mx-auto mt-8">
-          <h1 className="text-3xl font-bold mb-4 text-blue-800">How to Use MyWardBulletin</h1>
+          <h1 className="text-3xl font-bold mb-4 text-blue-800">How to Use {APP_NAME}</h1>
           <p className="mb-6 text-lg text-gray-700">
-            Creating and sharing a Sunday program should be simple. Here’s how to do it with MyWardBulletin:
+            Creating and sharing a Sunday program should be simple. Here’s how to do it with {APP_NAME}:
           </p>
           <ol className="list-decimal list-inside mb-6 space-y-6 text-gray-700">
             <li>
@@ -119,7 +120,7 @@ export default function HowToUsePage() {
 
           <h2 className="text-2xl font-bold mt-8 mb-4 text-blue-700">Announcement Submissions</h2>
           <p className="mb-4 text-gray-700">
-            MyWardBulletin now includes a collaborative announcement system that allows ward members to submit announcements directly to your bulletin!
+            {APP_NAME} now includes a collaborative announcement system that allows ward members to submit announcements directly to your bulletin!
           </p>
           
           <div className="bg-blue-50 rounded-lg p-6 mb-6">
@@ -176,9 +177,12 @@ export default function HowToUsePage() {
       <footer className="bg-white border-t border-gray-200 mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="text-center">
-            <p className="text-gray-600">
-              MyWardBulletin.com - Free Ward Bulletin Creator
-            </p>
+            {(APP_NAME || APP_TAGLINE) && (
+              <p className="text-gray-600">
+                {APP_NAME}
+                {APP_TAGLINE ? ` - ${APP_TAGLINE}` : ''}
+              </p>
+            )}
             <nav className="mt-4 space-x-4">
               <a href="/about" className="text-gray-600 hover:text-gray-900">About</a>
               <a href="/how-to-use" className="text-gray-600 hover:text-gray-900">How To Use</a>


### PR DESCRIPTION
## Summary
- allow customizing of branding via VITE_APP_NAME and VITE_APP_TAGLINE
- read brand settings in header and various pages
- update index.html to reference brand env vars
- document customization of brand and theme

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688babb0c024832a925ce91d38b1e7cf