### PR TITLE
Fix type imports and health endpoint

### DIFF
--- a/api/health.ts
+++ b/api/health.ts
@@ -1,0 +1,3 @@
+export default function handler(req: any, res: any) {
+  res.status(200).end();
+}

--- a/src/components/BulletinCustomization.tsx
+++ b/src/components/BulletinCustomization.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Palette, Type, Layout, Eye, EyeOff } from 'lucide-react';
-import { BulletinCustomization } from '../types/bulletin';
+import type { BulletinCustomization } from '../types/bulletin';
 
 interface BulletinCustomizationProps {
   customization: BulletinCustomization;

--- a/src/components/BulletinForm.tsx
+++ b/src/components/BulletinForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
-import { BulletinData, Announcement, Meeting, SpecialEvent, AgendaItem, BulletinCustomization } from '../types/bulletin';
+import type { BulletinData, Announcement, Meeting, SpecialEvent, AgendaItem, BulletinCustomization } from '../types/bulletin';
 import { getSongTitle, isValidSongNumber, searchSongsByTitle, SongType } from '../lib/songService';
 import { toast } from 'react-toastify';
 import ReactQuill from 'react-quill';

--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { BulletinData } from "../types/bulletin";
+import type { BulletinData } from "../types/bulletin";
 
 import { sanitizeHtml } from '../lib/sanitizeHtml';
 import { getSongUrl, getSongTitle } from '../lib/songService';

--- a/src/components/CustomizationTest.tsx
+++ b/src/components/CustomizationTest.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import { BulletinCustomization } from '../types/bulletin';
-import { runCustomizationTests, testDefaultCustomization, testColorPresets } from '../lib/customization.test';
+import type { BulletinCustomization } from '../types/bulletin';
+import { runCustomizationTests, testDefaultCustomization, testColorPresets } from '../lib/customizationHelpers';
 
 interface CustomizationTestProps {
   onClose: () => void;

--- a/src/components/PublicBulletinView.tsx
+++ b/src/components/PublicBulletinView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ArrowLeft, Home } from 'lucide-react';
 import BulletinPreview from './BulletinPreview';
-import { BulletinData } from '../types/bulletin';
+import type { BulletinData } from '../types/bulletin';
 
 interface PublicBulletinViewProps {
   bulletinData: BulletinData | null;

--- a/src/lib/customizationHelpers.ts
+++ b/src/lib/customizationHelpers.ts
@@ -1,4 +1,4 @@
-import { BulletinCustomization } from '../types/bulletin';
+import type { BulletinCustomization } from '../types/bulletin';
 
 // Test default customization values
 export const testDefaultCustomization: BulletinCustomization = {

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -15,7 +15,7 @@ import PublicBulletinView from '../components/PublicBulletinView';
 import SubmissionReviewModal from '../components/SubmissionReviewModal';
 import ConfirmationModal from '../components/ConfirmationModal';
 import CustomizationTest from '../components/CustomizationTest';
-import { BulletinData } from '../types/bulletin';
+import type { BulletinData } from '../types/bulletin';
 import templateService, { Template } from '../lib/templateService';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';


### PR DESCRIPTION
## Summary
- create `/api/health` for network checks
- rename `customization.test.ts` to `customizationHelpers.ts`
- reference new helpers in `CustomizationTest` component
- import bulletin types with `import type` so interfaces are not required at runtime

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bb672d3f0832a9ea276894df989f1