### PR TITLE
Fix announcement HTML rendering and image position handling

### DIFF
--- a/src/components/BulletinPrintLayout.tsx
+++ b/src/components/BulletinPrintLayout.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import { sanitizeHtml } from "../lib/sanitizeHtml";
+import { decodeHtml } from '../lib/decodeHtml';
 import { LDS_IMAGES, getImageById } from '../data/images';
 
 // Function to format date from ISO format to natural format
@@ -176,14 +177,8 @@ function BulletinPrintLayout({ data, refs }: { data: any, refs?: { page1?: React
           <h2 className="text-xl font-bold mb-4 print:!text-3xl print:!text-black">Announcements & Events</h2>
           <ul className="space-y-4">
             {data.announcements?.map((a: any, idx: number) => {
-              // Try to decode HTML entities if they're double-encoded
-              const decodedContent = a.content
-                .replace(/&lt;/g, '<')
-                .replace(/&gt;/g, '>')
-                .replace(/&amp;/g, '&')
-                .replace(/&quot;/g, '"')
-                .replace(/&#39;/g, "'");
-              
+              const decodedContent = sanitizeHtml(decodeHtml(a.content));
+
               return (
                 <li key={idx}>
                   {/* Audience and Category labels */}

--- a/src/lib/decodeHtml.ts
+++ b/src/lib/decodeHtml.ts
@@ -1,0 +1,9 @@
+export function decodeHtml(html: string): string {
+  if (!html) return '';
+  return html
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}

--- a/src/pages/PublicBulletinPage.tsx
+++ b/src/pages/PublicBulletinPage.tsx
@@ -49,7 +49,18 @@ export default function PublicBulletinPage() {
     meetingType: publicBulletin.meeting_type || '',
     theme: publicBulletin.theme || '',
     imageId: publicBulletin.imageId || 'none',
-    imagePosition: publicBulletin.imagePosition || { x: 50, y: 50 },
+    imagePosition: (() => {
+      const pos = publicBulletin.imagePosition;
+      if (!pos) return { x: 50, y: 50 };
+      if (typeof pos === 'string') {
+        try {
+          return JSON.parse(pos);
+        } catch {
+          return { x: 50, y: 50 };
+        }
+      }
+      return pos;
+    })(),
     bishopricMessage: publicBulletin.bishopric_message || '',
     announcements: publicBulletin.announcements || [],
     meetings: publicBulletin.meetings || [],


### PR DESCRIPTION
## Summary
- decode and sanitize announcement HTML before rendering so audience and category labels show correctly
- parse and apply saved image positions when displaying public bulletins
- share HTML decoding utility with print layout

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689414f584cc832a96513a814a159ae4