### PR TITLE
Fix announcement HTML rendering and image position handling

### DIFF
--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { BulletinData } from "../types/bulletin";
 import { sanitizeHtml } from '../lib/sanitizeHtml';
+import { decodeHtml } from '../lib/decodeHtml';
 import { getSongUrl, getSongTitle } from '../lib/songService';
 import { LDS_IMAGES, getImageById } from '../data/images';
 
@@ -8,6 +9,7 @@ interface BulletinPreviewProps {
   data: BulletinData;
   hideTabs?: boolean;
   hideImageControls?: boolean;
+  onImagePositionChange?: (pos: { x: number; y: number }) => void;
 }
 
 // Add audience label map and order at the top of the file
@@ -55,10 +57,19 @@ const imagePositions = {
   bottom: { x: 50, y: 75 }
 };
 
-export default function BulletinPreview({ data, hideTabs = false, hideImageControls = false }: BulletinPreviewProps) {
+export default function BulletinPreview({ data, hideTabs = false, hideImageControls = false, onImagePositionChange }: BulletinPreviewProps) {
   const [activeTab, setActiveTab] = useState<'program' | 'announcements' | 'wardinfo'>('program');
   const [imagePosition, setImagePosition] = useState(data.imagePosition || imagePositions.center);
   const [showImageControls, setShowImageControls] = useState(false);
+
+  const handleImagePositionChange = (pos: { x: number; y: number }) => {
+    setImagePosition(pos);
+    onImagePositionChange?.(pos);
+  };
+
+  useEffect(() => {
+    setImagePosition(data.imagePosition || imagePositions.center);
+  }, [data.imagePosition]);
 
   const formatDate = (dateString: string) => {
     // Fix timezone issue by creating date in local timezone
@@ -175,7 +186,7 @@ export default function BulletinPreview({ data, hideTabs = false, hideImageContr
                               {Object.entries(imagePositions).map(([key, pos]) => (
                                 <button
                                   key={key}
-                                  onClick={() => setImagePosition(pos)}
+                                  onClick={() => handleImagePositionChange(pos)}
                                   className={`px-3 py-2 text-xs rounded ${
                                     imagePosition.x === pos.x && imagePosition.y === pos.y
                                       ? 'bg-blue-500 text-white'
@@ -382,17 +393,25 @@ export default function BulletinPreview({ data, hideTabs = false, hideImageContr
             {/* Announcements */}
             {data.announcements && data.announcements.length > 0 ? (
               <div className="space-y-4">
-                {data.announcements.map((announcement, index) => (
-                  <div key={index} className="border-l-4 border-blue-500 pl-4">
-                    <h3 className="font-bold text-gray-900 mb-1">{announcement.title}</h3>
-                    <p className="text-gray-700 mb-2">{announcement.content}</p>
-                    {announcement.audience && (
-                      <span className="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded">
-                        {audienceLabels[announcement.audience] || announcement.audience}
-                      </span>
-                    )}
-                  </div>
-                ))}
+                {data.announcements.map((announcement, index) => {
+                  const decodedContent = sanitizeHtml(decodeHtml(announcement.content));
+                  return (
+                    <div key={index} className="border-l-4 border-blue-500 pl-4">
+                      <div className="mb-1">
+                        <span className="font-bold text-gray-900 text-sm mr-2">
+                          {audienceLabels[(announcement.audience || 'ward') as keyof typeof audienceLabels]}
+                        </span>
+                        {announcement.category && announcement.category.toLowerCase() !== 'general' && (
+                          <span className="text-gray-600 text-xs bg-gray-100 px-2 py-1 rounded">
+                            {announcement.category}
+                          </span>
+                        )}
+                      </div>
+                      <h3 className="font-bold text-gray-900 mb-1">{announcement.title}</h3>
+                      <div className="text-gray-700 mb-2" dangerouslySetInnerHTML={{ __html: decodedContent }} />
+                    </div>
+                  );
+                })}
               </div>
             ) : (
               <div className="text-center py-8 text-gray-500">
@@ -764,24 +783,18 @@ export default function BulletinPreview({ data, hideTabs = false, hideImageContr
         {data.announcements && data.announcements.length > 0 ? (
           <div className="space-y-4">
             {data.announcements.map((announcement, index) => {
-              // Debug: Log the raw content
-              console.log('Raw announcement content:', announcement.content);
-              
-              // Try to decode HTML entities if they're double-encoded
-              const decodedContent = announcement.content
-                .replace(/&lt;/g, '<')
-                .replace(/&gt;/g, '>')
-                .replace(/&amp;/g, '&')
-                .replace(/&quot;/g, '"')
-                .replace(/&#39;/g, "'");
-              
-              console.log('Decoded content:', decodedContent);
-              
+              const decodedContent = sanitizeHtml(decodeHtml(announcement.content));
               return (
                 <div key={index} className="text-sm">
                   <div className="mb-1">
-                    <span className="font-bold text-gray-900 text-sm mr-2">{audienceLabels[(announcement.audience || 'ward') as keyof typeof audienceLabels]}</span>
-                    <span className="text-gray-600 text-xs bg-gray-100 px-2 py-1 rounded">{announcement.category}</span>
+                    <span className="font-bold text-gray-900 text-sm mr-2">
+                      {audienceLabels[(announcement.audience || 'ward') as keyof typeof audienceLabels]}
+                    </span>
+                    {announcement.category && announcement.category.toLowerCase() !== 'general' && (
+                      <span className="text-gray-600 text-xs bg-gray-100 px-2 py-1 rounded">
+                        {announcement.category}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center mb-1">
                     <h4 className="font-semibold mr-2 text-gray-900">{announcement.title}</h4>

--- a/src/components/BulletinPrintLayout.tsx
+++ b/src/components/BulletinPrintLayout.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import { sanitizeHtml } from "../lib/sanitizeHtml";
+import { decodeHtml } from '../lib/decodeHtml';
 import { LDS_IMAGES, getImageById } from '../data/images';
 
 // Function to format date from ISO format to natural format
@@ -176,20 +177,16 @@ function BulletinPrintLayout({ data, refs }: { data: any, refs?: { page1?: React
           <h2 className="text-xl font-bold mb-4 print:!text-3xl print:!text-black">Announcements & Events</h2>
           <ul className="space-y-4">
             {data.announcements?.map((a: any, idx: number) => {
-              // Try to decode HTML entities if they're double-encoded
-              const decodedContent = a.content
-                .replace(/&lt;/g, '<')
-                .replace(/&gt;/g, '>')
-                .replace(/&amp;/g, '&')
-                .replace(/&quot;/g, '"')
-                .replace(/&#39;/g, "'");
-              
+              const decodedContent = sanitizeHtml(decodeHtml(a.content));
+
               return (
                 <li key={idx}>
                   {/* Audience and Category labels */}
                   <div className="font-bold print:!text-lg print:!text-black mb-1">
                     {audienceLabels[(a.audience as keyof typeof audienceLabels) || 'ward']}
-                    <span className="text-gray-600 text-xs bg-gray-100 px-2 py-1 rounded ml-2">{a.category}</span>
+                    {a.category && a.category.toLowerCase() !== 'general' && (
+                      <span className="text-gray-600 text-xs bg-gray-100 px-2 py-1 rounded ml-2">{a.category}</span>
+                    )}
                   </div>
                   <div className="font-semibold print:!text-2xl print:!text-black">{a.title}</div>
                   <div className="text-sm print:!text-lg print:!text-black" dangerouslySetInnerHTML={{ __html: decodedContent }} />

--- a/src/lib/decodeHtml.ts
+++ b/src/lib/decodeHtml.ts
@@ -1,0 +1,9 @@
+export function decodeHtml(html: string): string {
+  if (!html) return '';
+  return html
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -1051,7 +1051,12 @@ function EditorApp() {
                 )}
               </div>
               <div ref={bulletinRef}>
-                <BulletinPreview data={bulletinData} />
+                <BulletinPreview
+                  data={bulletinData}
+                  onImagePositionChange={(pos) =>
+                    handleBulletinDataChange({ ...bulletinData, imagePosition: pos })
+                  }
+                />
               </div>
               {user && currentBulletinId && activeBulletinId !== currentBulletinId && (
                 <button

--- a/src/pages/PublicBulletinPage.tsx
+++ b/src/pages/PublicBulletinPage.tsx
@@ -49,7 +49,18 @@ export default function PublicBulletinPage() {
     meetingType: publicBulletin.meeting_type || '',
     theme: publicBulletin.theme || '',
     imageId: publicBulletin.imageId || 'none',
-    imagePosition: publicBulletin.imagePosition || { x: 50, y: 50 },
+    imagePosition: (() => {
+      const pos = publicBulletin.imagePosition;
+      if (!pos) return { x: 50, y: 50 };
+      if (typeof pos === 'string') {
+        try {
+          return JSON.parse(pos);
+        } catch {
+          return { x: 50, y: 50 };
+        }
+      }
+      return pos;
+    })(),
     bishopricMessage: publicBulletin.bishopric_message || '',
     announcements: publicBulletin.announcements || [],
     meetings: publicBulletin.meetings || [],


### PR DESCRIPTION
## Summary
- decode and sanitize announcement HTML before rendering so audience and category labels show correctly
- parse and apply saved image positions when displaying public bulletins
- share HTML decoding utility with print layout
- hide "General" category tags in announcements and persist image alignment selections

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689414f584cc832a96513a814a159ae4