### PR TITLE
Introduce user-selected theme for the printed program

### DIFF
--- a/src/components/BulletinPreview.tsx
+++ b/src/components/BulletinPreview.tsx
@@ -269,7 +269,8 @@ export default function BulletinPreview({
   data,
   hideTabs = false,
   hideImageControls = false,
-  onImagePositionChange
+  onImagePositionChange,
+  onThemeSelectClick,
 }: BulletinPreviewProps) {
   const [activeTab, setActiveTab] = useState<'program' | 'announcements' | 'unitinfo'>('program');
 

--- a/src/components/BulletinPrintLayout.tsx
+++ b/src/components/BulletinPrintLayout.tsx
@@ -3,6 +3,7 @@ import { sanitizeHtml } from "../lib/sanitizeHtml";
 import { decodeHtml } from '../lib/decodeHtml';
 import { LDS_IMAGES, getImageById } from '../data/images';
 import { useSession } from '../lib/SessionContext';
+import { themes } from '../data/themes';
 
 
 import QRCode from 'qrcode';
@@ -73,8 +74,10 @@ function BulletinPrintLayout({ data, refs }: { data: any, refs?: { page1?: React
   // Check if there's any meaningful ward info to display
   const hasWardInfo = filteredWardLeadership.length > 0 || filteredMissionaries.length > 0 || filteredWardMissionaries.length > 0;
 
+  const selectedTheme = themes.find(t => t.name === data.userTheme);
+
   return (
-    <div className="print-layout font-sans">
+    <div className="print-layout font-sans" style={{ fontFamily: selectedTheme ? selectedTheme.fontFamily : 'sans-serif' }}>
       {/* Page 1: Outside (landscape) */}
       <div
         ref={refs?.page1}

--- a/src/components/PrintPreviewModal.tsx
+++ b/src/components/PrintPreviewModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import BulletinPrintLayout from './BulletinPrintLayout';
+import { BulletinData } from '../types/bulletin';
+
+interface PrintPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  bulletinData: BulletinData;
+}
+
+export default function PrintPreviewModal({ isOpen, onClose, bulletinData }: PrintPreviewModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-6xl mx-4 h-full overflow-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-xl font-semibold">Print Preview</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+        </div>
+        <BulletinPrintLayout data={bulletinData} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ThemeModal.tsx
+++ b/src/components/ThemeModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { themes } from '../data/themes';
+
+interface ThemeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectTheme: (theme: { name: string; fontFamily: string }) => void;
+  currentUserTheme: string;
+}
+
+export default function ThemeModal({ isOpen, onClose, onSelectTheme, currentUserTheme }: ThemeModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md mx-4" onClick={(e) => e.stopPropagation()}>
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-xl font-semibold">Select a Theme</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">&times;</button>
+        </div>
+        <div className="space-y-2">
+          {themes.map((theme) => (
+            <button
+              key={theme.name}
+              onClick={() => onSelectTheme(theme)}
+              className={`w-full text-left px-4 py-2 rounded-lg ${currentUserTheme === theme.name ? 'bg-blue-500 text-white' : 'hover:bg-gray-100'}`}
+              style={{ fontFamily: theme.fontFamily }}
+            >
+              {theme.name}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/themes.ts
+++ b/src/data/themes.ts
@@ -1,0 +1,11 @@
+export const themes = [
+  { name: 'Formal', fontFamily: 'Georgia, serif' },
+  { name: 'Simple', fontFamily: 'Arial, sans-serif' },
+  { name: 'Modern', fontFamily: 'Verdana, sans-serif' },
+  { name: 'Elegant', fontFamily: 'Tahoma, sans-serif' },
+  { name: 'Friendly', fontFamily: '\'Trebuchet MS\', sans-serif' },
+  { name: 'Traditional', fontFamily: '\'Times New Roman\', serif' },
+  { name: 'Timeless', fontFamily: 'Garamond, serif' },
+  { name: 'Typewritten', fontFamily: '\'Courier New\', monospace' },
+  { name: 'Handwritten', fontFamily: '\'Brush Script MT\', cursive' },
+];

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -313,6 +313,7 @@ export const bulletinService = {
       created_at: new Date().toISOString(),
       ward_name: bulletinData.wardName,
       theme: bulletinData.theme || '',
+      userTheme: bulletinData.userTheme || '',
       bishopric_message: bulletinData.bishopricMessage || '',
       announcements: bulletinData.announcements || [],
       meetings: bulletinData.meetings || [],
@@ -333,6 +334,7 @@ export const bulletinService = {
       const tokens = [
         { key: `bulletin-${slug}-ward_name`, value: bulletinData.wardName || '', created_by: userId },
         { key: `bulletin-${slug}-theme`, value: bulletinData.theme || '', created_by: userId },
+        { key: `bulletin-${slug}-userTheme`, value: bulletinData.userTheme || '', created_by: userId },
         { key: `bulletin-${slug}-bishopric`, value: bulletinData.bishopricMessage || '', created_by: userId },
         { key: `bulletin-${slug}-announcements`, value: JSON.stringify(bulletinData.announcements || []), created_by: userId },
         { key: `bulletin-${slug}-meetings`, value: JSON.stringify(bulletinData.meetings || []), created_by: userId },
@@ -479,6 +481,7 @@ export const bulletinService = {
             const tokenPromises = [
               tokenService.getToken(userId, `bulletin-${bulletin.slug}-ward_name`),
               tokenService.getToken(userId, `bulletin-${bulletin.slug}-theme`),
+              tokenService.getToken(userId, `bulletin-${bulletin.slug}-userTheme`),
               tokenService.getToken(userId, `bulletin-${bulletin.slug}-bishopric`),
               tokenService.getToken(userId, `bulletin-${bulletin.slug}-announcements`),
               tokenService.getToken(userId, `bulletin-${bulletin.slug}-meetings`),
@@ -497,11 +500,11 @@ export const bulletinService = {
             tokenPromises.push(tokenService.getToken(userId, `bulletin-${bulletin.slug}-imagePosition`));
             
             const tokenResults = await Promise.all(tokenPromises);
-            const [wardName, theme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 13);
+            const [wardName, theme, userTheme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 14);
             
             // Handle image tokens (always fetched)
-            const image = tokenResults[13];
-            const imagePosition = tokenResults[14];
+            const image = tokenResults[14];
+            const imagePosition = tokenResults[15];
 
             return {
               id: bulletin.id,
@@ -510,6 +513,7 @@ export const bulletinService = {
               date: bulletin.meeting_date,
               meeting_type: bulletin.meeting_type,
               theme: theme || '',
+              userTheme: userTheme || '',
               bishopric_message: bishopric || '',
               announcements: announcements ? JSON.parse(announcements) : [],
               meetings: meetings ? JSON.parse(meetings) : [],
@@ -596,6 +600,7 @@ export const bulletinService = {
     const tokenPromises = [
       tokenService.getToken(userId, `bulletin-${data.slug}-ward_name`),
       tokenService.getToken(userId, `bulletin-${data.slug}-theme`),
+      tokenService.getToken(userId, `bulletin-${data.slug}-userTheme`),
       tokenService.getToken(userId, `bulletin-${data.slug}-bishopric`),
       tokenService.getToken(userId, `bulletin-${data.slug}-announcements`),
       tokenService.getToken(userId, `bulletin-${data.slug}-meetings`),
@@ -614,11 +619,11 @@ export const bulletinService = {
     tokenPromises.push(tokenService.getToken(userId, `bulletin-${data.slug}-imagePosition`));
     
     const tokenResults = await Promise.all(tokenPromises);
-    const [wardName, theme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 13);
+    const [wardName, theme, userTheme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 14);
     
     // Handle image tokens (always fetched)
-    const image = tokenResults[13];
-    const imagePosition = tokenResults[14];
+    const image = tokenResults[14];
+    const imagePosition = tokenResults[15];
 
     return {
       id: data.id,
@@ -628,6 +633,7 @@ export const bulletinService = {
       date: data.meeting_date,
       meeting_type: data.meeting_type,
       theme: theme || '',
+      userTheme: userTheme || '',
       bishopric_message: bishopric || '',
       announcements: announcements ? JSON.parse(announcements) : [],
       meetings: meetings ? JSON.parse(meetings) : [],
@@ -710,6 +716,7 @@ export const bulletinService = {
     const tokenPromises = [
       tokenService.getToken(userId, `bulletin-${data.slug}-ward_name`),
       tokenService.getToken(userId, `bulletin-${data.slug}-theme`),
+      tokenService.getToken(userId, `bulletin-${data.slug}-userTheme`),
       tokenService.getToken(userId, `bulletin-${data.slug}-bishopric`),
       tokenService.getToken(userId, `bulletin-${data.slug}-announcements`),
       tokenService.getToken(userId, `bulletin-${data.slug}-meetings`),
@@ -728,11 +735,11 @@ export const bulletinService = {
     tokenPromises.push(tokenService.getToken(userId, `bulletin-${data.slug}-imagePosition`));
     
     const tokenResults = await Promise.all(tokenPromises);
-    const [wardName, theme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 13);
+    const [wardName, theme, userTheme, bishopric, announcements, meetings, events, agenda, prayers, music, leadership, wardLeadership, missionaries, wardMissionaries] = tokenResults.slice(0, 14);
     
     // Handle image tokens (always fetched)
-    const image = tokenResults[13];
-    const imagePosition = tokenResults[14];
+    const image = tokenResults[14];
+    const imagePosition = tokenResults[15];
 
     const result = {
       id: data.id,
@@ -742,6 +749,7 @@ export const bulletinService = {
       date: data.meeting_date,
       meeting_type: data.meeting_type,
       theme: theme || '',
+      userTheme: userTheme || '',
       imageId: image || 'none',
       imagePosition: imagePosition ? JSON.parse(imagePosition) : { x: 50, y: 50 },
       bishopric_message: bishopric || '',

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Plus, Download, QrCode, LogIn, Menu, X, MessageSquare, Repeat } from 'lucide-react';
+import { Plus, Download, QrCode, LogIn, Menu, X, MessageSquare, Repeat, Paintbrush, Printer } from 'lucide-react';
 import UnitTypeSelector from '../components/TerminologyToggle';
 import { getCurrentUnitType } from '../lib/config';
 import jsPDF from 'jspdf';
@@ -13,6 +13,8 @@ import AuthModal from '../components/AuthModal';
 import UserMenu from '../components/UserMenu';
 import SavedBulletinsModal from '../components/SavedBulletinsModal';
 import TemplatesModal from '../components/TemplatesModal';
+import ThemeModal from '../components/ThemeModal';
+import PrintPreviewModal from '../components/PrintPreviewModal';
 import ProfileModal from '../components/ProfileModal';
 import PublicBulletinView from '../components/PublicBulletinView';
 import SubmissionReviewModal from '../components/SubmissionReviewModal';
@@ -25,6 +27,7 @@ import Logo from '../components/Logo';
 import BulletinPrintLayout from '../components/BulletinPrintLayout';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import { useSession } from '../lib/SessionContext';
+import { themes } from '../data/themes';
 import { handleError, NetworkError, DatabaseError, withErrorHandling, withRetry } from '../lib/errorHandler';
 
 
@@ -55,6 +58,8 @@ function EditorApp() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showSavedBulletins, setShowSavedBulletins] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
+  const [showThemeModal, setShowThemeModal] = useState(false);
+  const [showPrintPreviewModal, setShowPrintPreviewModal] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSubmissionReview, setShowSubmissionReview] = useState(false);
   const [pendingSubmissionsCount, setPendingSubmissionsCount] = useState(0);
@@ -175,6 +180,7 @@ function EditorApp() {
       date: new Date().toISOString().split('T')[0],
       meetingType: getMeetingTypeForUnit(currentUnitType),
       theme: '',
+      userTheme: '',
       bishopricMessage: '',
       announcements: [],
       meetings: [],
@@ -382,6 +388,7 @@ function EditorApp() {
     date: bulletin.date,
     meetingType: bulletin.meeting_type,
     theme: bulletin.theme || '',
+    userTheme: bulletin.userTheme || '',
     bishopricMessage: bulletin.bishopric_message || '',
     announcements: bulletin.announcements || [],
     meetings: bulletin.meetings || [],
@@ -1250,6 +1257,26 @@ function EditorApp() {
                 <h2 className="text-2xl font-semibold text-gray-900">
                 Bulletin Preview
                 </h2>
+                <button
+                  onClick={() => setShowPrintPreviewModal(true)}
+                  className="inline-flex items-center px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors"
+                >
+                  <Printer className="w-4 h-4 mr-2" />
+                  Print Preview
+                </button>
+                <button
+                  onClick={() => setShowThemeModal(true)}
+                  className="inline-flex items-baseline px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors"
+                >
+                  <Paintbrush className="w-4 h-4 mr-2" />
+                  {bulletinData.userTheme ? (
+                    <>
+                      Theme: <span style={{ fontFamily: themes.find(t => t.name === bulletinData.userTheme)?.fontFamily, marginLeft: '0.25rem' }}>{bulletinData.userTheme}</span>
+                    </>
+                  ) : (
+                    'Theme'
+                  )}
+                </button>
                 {currentBulletinId && (
                   <div className="flex flex-col sm:flex-row sm:justify-end sm:items-center gap-2 mb-2">
                     <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">
@@ -1386,6 +1413,16 @@ function EditorApp() {
           onSelect={handleTemplateSelect}
         />
 
+        <ThemeModal
+          isOpen={showThemeModal}
+          onClose={() => setShowThemeModal(false)}
+          onSelectTheme={(theme) => {
+            handleBulletinDataChange({ ...bulletinData, userTheme: theme.name });
+            setShowThemeModal(false);
+          }}
+          currentUserTheme={bulletinData.userTheme}
+        />
+
         {/* Profile Modal */}
         <ProfileModal
           isOpen={showProfile}
@@ -1453,6 +1490,12 @@ function EditorApp() {
           title={confirmationModal.title}
           message={confirmationModal.message}
           variant={confirmationModal.variant}
+        />
+
+        <PrintPreviewModal
+          isOpen={showPrintPreviewModal}
+          onClose={() => setShowPrintPreviewModal(false)}
+          bulletinData={bulletinData}
         />
 
         {/* Hidden print layout for PDF export */}

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -1252,44 +1252,51 @@ function EditorApp() {
 
           {/* Preview Section */}
           <div className="space-y-6">
-            <div className="bg-white rounded-xl shadow-lg p-6">
-              <div className="flex justify-between items-center mb-6">
-                <h2 className="text-2xl font-semibold text-gray-900">
-                Bulletin Preview
+            <div className="bg-white rounded-xl shadow-lg p-4 sm:p-6">
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-6 space-y-3 sm:space-y-0">
+                <h2 className="text-xl sm:text-2xl font-semibold text-gray-900">
+                  Bulletin Preview
                 </h2>
-                <button
-                  onClick={() => setShowPrintPreviewModal(true)}
-                  className="inline-flex items-center px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors"
-                >
-                  <Printer className="w-4 h-4 mr-2" />
-                  Print Preview
-                </button>
-                <button
-                  onClick={() => setShowThemeModal(true)}
-                  className="inline-flex items-baseline px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors"
-                >
-                  <Paintbrush className="w-4 h-4 mr-2" />
-                  {bulletinData.userTheme ? (
-                    <>
-                      Theme: <span style={{ fontFamily: themes.find(t => t.name === bulletinData.userTheme)?.fontFamily, marginLeft: '0.25rem' }}>{bulletinData.userTheme}</span>
-                    </>
-                  ) : (
-                    'Theme'
-                  )}
-                </button>
-                {currentBulletinId && (
-                  <div className="flex flex-col sm:flex-row sm:justify-end sm:items-center gap-2 mb-2">
-                    <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">
-                      Saved Bulletin
-                    </span>
-                    {hasUnsavedChanges && (
-                      <span className="bg-orange-100 text-orange-800 px-2 py-1 rounded-full text-xs">
-                        Unsaved Changes
-                      </span>
+                <div className="flex flex-col sm:flex-row gap-2 sm:gap-3">
+                  <button
+                    onClick={() => setShowPrintPreviewModal(true)}
+                    className="inline-flex items-center justify-center px-3 sm:px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors text-sm sm:text-base"
+                  >
+                    <Printer className="w-4 h-4 mr-2" />
+                    <span className="hidden sm:inline">Print Preview</span>
+                    <span className="sm:hidden">Print</span>
+                  </button>
+                  <button
+                    onClick={() => setShowThemeModal(true)}
+                    className="inline-flex items-center justify-center px-3 sm:px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors text-sm sm:text-base"
+                  >
+                    <Paintbrush className="w-4 h-4 mr-2" />
+                    {bulletinData.userTheme ? (
+                      <>
+                        <span className="hidden sm:inline">Theme: </span>
+                        <span className="sm:hidden">Theme: </span>
+                        <span style={{ fontFamily: themes.find(t => t.name === bulletinData.userTheme)?.fontFamily }}>
+                          {bulletinData.userTheme.length > 8 ? bulletinData.userTheme.substring(0, 8) + '...' : bulletinData.userTheme}
+                        </span>
+                      </>
+                    ) : (
+                      'Theme'
                     )}
-                  </div>
-                )}
+                  </button>
+                </div>
               </div>
+              {currentBulletinId && (
+                <div className="flex flex-col sm:flex-row sm:justify-end sm:items-center gap-2 mb-4">
+                  <span className="bg-green-100 text-green-800 px-2 py-1 rounded-full text-xs">
+                    Saved Bulletin
+                  </span>
+                  {hasUnsavedChanges && (
+                    <span className="bg-orange-100 text-orange-800 px-2 py-1 rounded-full text-xs">
+                      Unsaved Changes
+                    </span>
+                  )}
+                </div>
+              )}
               <div ref={bulletinRef}>
                 <BulletinPreview 
                   data={bulletinData} 

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -108,6 +108,7 @@ export interface BulletinData {
   date: string;
   meetingType: string;
   theme: string;
+  userTheme: string;
   bishopricMessage: string; // Will display as appropriate leadership message based on terminology
   announcements: Announcement[];
   meetings: Meeting[];


### PR DESCRIPTION
* "Print Preview" button that renders the BulletinPrintLayout inside a PrintPreviewModal
* Theme button that displays a modal to select a theme for printing

At present, the theme sets a font using inline styles and not Tailwind CSS. Further, it simply sets it at the top-level <div /> and allows cascading to happen.

I think there can be a more comprehensive theming that could be done. For instance, should only the larger titles use the theme font, while the rest of the text uses the current default font?