### PR TITLE
Fix password reset redirect and improve error visibility

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
-import { AlertTriangle, RefreshCw, Home, ArrowLeft } from 'lucide-react';
+import { AlertTriangle, RefreshCw, Home, ArrowLeft, Copy, Check } from 'lucide-react';
 
 interface Props {
   children: ReactNode;
@@ -11,6 +11,7 @@ interface State {
   hasError: boolean;
   error: Error | null;
   errorInfo: ErrorInfo | null;
+  copied: boolean;
 }
 
 export default class ErrorBoundary extends Component<Props, State> {
@@ -19,7 +20,8 @@ export default class ErrorBoundary extends Component<Props, State> {
     this.state = {
       hasError: false,
       error: null,
-      errorInfo: null
+      errorInfo: null,
+      copied: false
     };
   }
 
@@ -27,7 +29,8 @@ export default class ErrorBoundary extends Component<Props, State> {
     return {
       hasError: true,
       error,
-      errorInfo: null
+      errorInfo: null,
+      copied: false
     };
   }
 
@@ -52,7 +55,8 @@ export default class ErrorBoundary extends Component<Props, State> {
     this.setState({
       hasError: false,
       error: null,
-      errorInfo: null
+      errorInfo: null,
+      copied: false
     });
   };
 
@@ -62,6 +66,30 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   handleGoBack = () => {
     window.history.back();
+  };
+
+  buildErrorReport = (): string => {
+    const { error, errorInfo } = this.state;
+    const url = typeof window !== 'undefined' ? window.location.href : 'unknown';
+    const ts = new Date().toISOString();
+    const lines = [
+      `Time: ${ts}`,
+      `URL: ${url}`,
+      `Error: ${error?.message ?? 'unknown'}`
+    ];
+    if (error?.stack) lines.push(`Stack:\n${error.stack}`);
+    if (errorInfo?.componentStack) lines.push(`Component stack:\n${errorInfo.componentStack}`);
+    return lines.join('\n\n');
+  };
+
+  handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(this.buildErrorReport());
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 2000);
+    } catch {
+      // Clipboard API unavailable — leave the textarea visible so user can copy manually
+    }
   };
 
   render() {
@@ -87,24 +115,40 @@ export default class ErrorBoundary extends Component<Props, State> {
               </p>
             </div>
 
-            {process.env.NODE_ENV === 'development' && this.state.error && (
+            {this.state.error && (
               <details className="mb-6 text-left">
                 <summary className="cursor-pointer text-sm font-medium text-gray-700 mb-2">
-                  Error Details (Development)
+                  Error details (please include when contacting support)
                 </summary>
-                <div className="bg-gray-100 rounded-lg p-4 text-xs font-mono text-gray-800 overflow-auto max-h-32">
+                <div className="bg-gray-100 rounded-lg p-4 text-xs font-mono text-gray-800 overflow-auto max-h-48">
                   <div className="mb-2">
                     <strong>Error:</strong> {this.state.error.message}
                   </div>
-                  {this.state.errorInfo && (
+                  {this.state.errorInfo?.componentStack && (
                     <div>
-                      <strong>Stack:</strong>
+                      <strong>Component stack:</strong>
                       <pre className="whitespace-pre-wrap mt-1">
                         {this.state.errorInfo.componentStack}
                       </pre>
                     </div>
                   )}
                 </div>
+                <button
+                  onClick={this.handleCopy}
+                  className="mt-2 inline-flex items-center text-xs text-blue-600 hover:text-blue-700"
+                >
+                  {this.state.copied ? (
+                    <>
+                      <Check className="w-3 h-3 mr-1" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="w-3 h-3 mr-1" />
+                      Copy details
+                    </>
+                  )}
+                </button>
               </details>
             )}
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -11,6 +11,23 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Supabase configuration is required')
 }
 
+// If the URL carries a Supabase password-recovery hash, redirect to /reset-password
+// before the client below consumes it. Otherwise the recovery event fires before any
+// React listener is attached and the user lands signed-in on / with no way to set a
+// new password.
+if (typeof window !== 'undefined') {
+  const hash = window.location.hash
+  if (
+    hash.includes('type=recovery') &&
+    window.location.pathname !== '/reset-password'
+  ) {
+    try {
+      sessionStorage.setItem('password_recovery_hash', hash)
+    } catch (_) {}
+    window.location.replace('/reset-password' + hash)
+  }
+}
+
 // Create Supabase client with better error handling
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {

--- a/src/pages/EditorApp.tsx
+++ b/src/pages/EditorApp.tsx
@@ -1017,141 +1017,96 @@ function EditorApp() {
   };
 
   const handleLoadSavedBulletin = (bulletin: any) => {
-    // Check for unsaved changes
+    const defaultWardLeadership = [
+      { title: 'Bishop', name: '', phone: '' },
+      { title: '1st Counselor', name: '', phone: '' },
+      { title: '2nd Counselor', name: '', phone: '' },
+      { title: 'Executive Secretary', name: '', phone: '' },
+      { title: 'Ward Clerk', name: '', phone: '' },
+      { title: 'Elders Quorum President', name: '', phone: '' },
+      { title: 'Relief Society President', name: '', phone: '' },
+      { title: 'Young Women\'s President', name: '', phone: '' },
+      { title: 'Primary President', name: '', phone: '' },
+      { title: 'Sunday School President', name: '', phone: '' },
+      { title: 'Ward Mission Leader', name: '', phone: '' },
+      { title: 'Building Representative', name: '', phone: '' },
+      { title: 'Temple & Family History', name: '', phone: '' }
+    ];
+    const asArray = (v: unknown) => (Array.isArray(v) ? v : []);
+    const asObject = <T extends object>(v: unknown, fallback: T): T =>
+      v && typeof v === 'object' && !Array.isArray(v) ? (v as T) : fallback;
+
+    const applyLoad = () => {
+      try {
+        const loadedData: BulletinData = {
+          wardName: bulletin.ward_name || '',
+          date: bulletin.date,
+          meetingType: bulletin.meeting_type,
+          theme: bulletin.theme || '',
+          bishopricMessage: bulletin.bishopric_message || '',
+          announcements: asArray(bulletin.announcements),
+          meetings: asArray(bulletin.meetings),
+          specialEvents: asArray(bulletin.special_events),
+          agenda: ensureSacramentItem(asArray(bulletin.agenda), bulletin.meeting_type),
+          prayers: asObject(bulletin.prayers, {
+            opening: '',
+            closing: '',
+            invocation: '',
+            benediction: ''
+          }),
+          musicProgram: asObject(bulletin.music_program, {
+            openingHymn: '',
+            openingHymnNumber: '',
+            openingHymnTitle: '',
+            sacramentHymn: '',
+            sacramentHymnNumber: '',
+            sacramentHymnTitle: '',
+            closingHymn: '',
+            closingHymnNumber: '',
+            closingHymnTitle: ''
+          }),
+          leadership: asObject(bulletin.leadership, {
+            presiding: '',
+            chorister: '',
+            organist: ''
+          }),
+          status: bulletin.status || 'draft',
+          scheduledDate: bulletin.scheduled_date,
+          autoActivate: bulletin.auto_activate,
+          wardLeadership: asArray(bulletin.wardLeadership).length
+            ? asArray(bulletin.wardLeadership)
+            : defaultWardLeadership,
+          missionaries: asArray(bulletin.missionaries),
+          wardMissionaries: asArray(bulletin.wardMissionaries),
+          imageId: bulletin.imageId || 'none',
+          imagePosition: asObject(bulletin.imagePosition, { x: 50, y: 50 })
+        };
+
+        setBulletinData(loadedData);
+        setCurrentBulletinId(bulletin.id);
+        setHasUnsavedChanges(false);
+        setShowSavedBulletins(false);
+        setShowQRCode(false);
+      } catch (err) {
+        console.error('Failed to load bulletin', { id: bulletin?.id, bulletin, error: err });
+        toast.error(
+          `Couldn't load this bulletin (id: ${bulletin?.id ?? 'unknown'}). Please contact support with this ID.`
+        );
+      }
+    };
+
     if (hasUnsavedChanges) {
       setConfirmationModal({
         isOpen: true,
         title: 'Unsaved Changes',
         message: 'You have unsaved changes. Loading this bulletin will discard them. Continue?',
-        onConfirm: () => {
-          // Convert database format back to app format
-          const loadedData: BulletinData = {
-            wardName: bulletin.ward_name,
-            date: bulletin.date,
-            meetingType: bulletin.meeting_type,
-            theme: bulletin.theme || '',
-            bishopricMessage: bulletin.bishopric_message || '',
-            announcements: bulletin.announcements || [],
-            meetings: bulletin.meetings || [],
-            specialEvents: bulletin.special_events || [],
-            agenda: ensureSacramentItem(bulletin.agenda || [], bulletin.meeting_type),
-            prayers: bulletin.prayers || {
-              opening: '',
-              closing: '',
-              invocation: '',
-              benediction: ''
-            },
-            musicProgram: bulletin.music_program || {
-              openingHymn: '',
-              openingHymnNumber: '',
-              openingHymnTitle: '',
-              sacramentHymn: '',
-              sacramentHymnNumber: '',
-              sacramentHymnTitle: '',
-              closingHymn: '',
-              closingHymnNumber: '',
-              closingHymnTitle: ''
-            },
-            leadership: bulletin.leadership || {
-              presiding: '',
-              chorister: '',
-              organist: ''
-            },
-            wardLeadership: bulletin.wardLeadership || [
-              { title: 'Bishop', name: '', phone: '' },
-              { title: '1st Counselor', name: '', phone: '' },
-              { title: '2nd Counselor', name: '', phone: '' },
-              { title: 'Executive Secretary', name: '', phone: '' },
-              { title: 'Ward Clerk', name: '', phone: '' },
-              { title: 'Elders Quorum President', name: '', phone: '' },
-              { title: 'Relief Society President', name: '', phone: '' },
-              { title: 'Young Women\'s President', name: '', phone: '' },
-              { title: 'Primary President', name: '', phone: '' },
-              { title: 'Sunday School President', name: '', phone: '' },
-              { title: 'Ward Mission Leader', name: '', phone: '' },
-              { title: 'Building Representative', name: '', phone: '' },
-              { title: 'Temple & Family History', name: '', phone: '' }
-            ],
-            missionaries: bulletin.missionaries || [],
-            wardMissionaries: bulletin.wardMissionaries || [],
-            imageId: bulletin.imageId || 'none',
-            imagePosition: bulletin.imagePosition || { x: 50, y: 50 }
-          };
-
-          setBulletinData(loadedData);
-          setCurrentBulletinId(bulletin.id);
-          setHasUnsavedChanges(false);
-          setShowSavedBulletins(false);
-          setShowQRCode(false);
-        },
+        onConfirm: applyLoad,
         variant: 'warning'
       });
       return;
     }
 
-    // Convert database format back to app format
-    const loadedData: BulletinData = {
-      wardName: bulletin.ward_name,
-      date: bulletin.date,
-      meetingType: bulletin.meeting_type,
-      theme: bulletin.theme || '',
-      bishopricMessage: bulletin.bishopric_message || '',
-      announcements: bulletin.announcements || [],
-      meetings: bulletin.meetings || [],
-      specialEvents: bulletin.special_events || [],
-      agenda: ensureSacramentItem(bulletin.agenda || [], bulletin.meeting_type),
-      prayers: bulletin.prayers || {
-        opening: '',
-        closing: '',
-        invocation: '',
-        benediction: ''
-      },
-      musicProgram: bulletin.music_program || {
-        openingHymn: '',
-        openingHymnNumber: '',
-        openingHymnTitle: '',
-        sacramentHymn: '',
-        sacramentHymnNumber: '',
-        sacramentHymnTitle: '',
-        closingHymn: '',
-        closingHymnNumber: '',
-        closingHymnTitle: ''
-      },
-      leadership: bulletin.leadership || {
-        presiding: '',
-        chorister: '',
-        organist: ''
-      },
-      // Include status and scheduling fields
-      status: bulletin.status || 'draft',
-      scheduledDate: bulletin.scheduled_date,
-      autoActivate: bulletin.auto_activate,
-      wardLeadership: bulletin.wardLeadership || [
-        { title: 'Bishop', name: '', phone: '' },
-        { title: '1st Counselor', name: '', phone: '' },
-        { title: '2nd Counselor', name: '', phone: '' },
-        { title: 'Executive Secretary', name: '', phone: '' },
-        { title: 'Ward Clerk', name: '', phone: '' },
-        { title: 'Elders Quorum President', name: '', phone: '' },
-        { title: 'Relief Society President', name: '', phone: '' },
-        { title: 'Young Women\'s President', name: '', phone: '' },
-        { title: 'Primary President', name: '', phone: '' },
-        { title: 'Sunday School President', name: '', phone: '' },
-        { title: 'Ward Mission Leader', name: '', phone: '' },
-        { title: 'Building Representative', name: '', phone: '' },
-        { title: 'Temple & Family History', name: '', phone: '' }
-      ],
-      missionaries: bulletin.missionaries || [],
-      wardMissionaries: bulletin.wardMissionaries || [],
-      imageId: bulletin.imageId || 'none',
-      imagePosition: bulletin.imagePosition || { x: 50, y: 50 }
-    };
-
-    setBulletinData(loadedData);
-    setCurrentBulletinId(bulletin.id);
-    setHasUnsavedChanges(false);
-    setShowSavedBulletins(false);
-    setShowQRCode(false);
+    applyLoad();
   };
 
   const handleTemplateSelect = (template: Template | null, builtIn?: BuiltInTemplate) => {


### PR DESCRIPTION
## Summary

- **Password reset redirect:** Catch the Supabase `#type=recovery` hash at app startup (before the supabase client consumes it) and redirect to `/reset-password`. Fixes the loop a user reported where the reset email logged them in on `/` with no path to set a new password.
- **Bulletin load resilience:** Add `Array.isArray` / object-shape guards and a try/catch around `handleLoadSavedBulletin`. A malformed field now surfaces a toast with the bulletin id instead of crashing the editor into the ErrorBoundary. Also dedupes the conversion logic that was copy-pasted across the unsaved-changes branch and the no-unsaved-changes branch.
- **ErrorBoundary telemetry:** Always show the error message + component stack (previously gated to dev only). Adds a "Copy details" button that copies a structured report (timestamp, URL, error, stacks) so users can paste it back when contacting support.

## Test plan

- [ ] Type-check passes (`npm run type-check`) ✅ verified locally
- [ ] Tests pass aside from the pre-existing `baptism_ordinance` fixture failure ✅ verified locally
- [ ] After deploy: trigger "forgot password," click email link, confirm landing on `/reset-password` form with no current-password requirement
- [ ] After deploy: load a saved bulletin successfully (smoke test)
- [ ] After deploy: confirm ErrorBoundary "Copy details" button works if any crash occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)