### PR TITLE
Fix React error #310 in confirm dialogs + add Rules-of-Hooks CI gate

### DIFF
--- a/.github/workflows/lint-hooks.yml
+++ b/.github/workflows/lint-hooks.yml
@@ -1,0 +1,24 @@
+name: Lint (React Hooks)
+
+# Gate that blocks React Rules-of-Hooks violations — the class of bug behind
+# React error #310 ("Rendered more hooks than during the previous render").
+# Scoped to a single rule via eslint.hooks.config.js so it isn't blocked by the
+# repo's pre-existing lint errors. Once the full `npm run lint` is clean this
+# can be replaced by the broader gate.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint:hooks

--- a/eslint.hooks.config.js
+++ b/eslint.hooks.config.js
@@ -1,0 +1,33 @@
+// Minimal ESLint config that enforces ONLY react-hooks/rules-of-hooks.
+//
+// The full `eslint.config.js` currently surfaces hundreds of pre-existing
+// style/type errors, so it can't be used as a merge gate today. This config
+// parses TS/TSX but enables a single rule, so CI (and an optional pre-commit
+// hook) can block Rules-of-Hooks violations — the class of bug behind
+// React error #310 ("Rendered more hooks than during the previous render") —
+// without being drowned out by unrelated lint noise.
+//
+// Run with: npm run lint:hooks
+import reactHooks from 'eslint-plugin-react-hooks';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.{ts,tsx}'],
+    // Don't flag the repo's existing `eslint-disable` comments (for rules this
+    // slim config doesn't enable) as "unused".
+    linterOptions: { reportUnusedDisableDirectives: false },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    // react-hooks supplies the one rule we enforce; @typescript-eslint is
+    // registered only so inline disable comments referencing its rules resolve
+    // (its rules stay off).
+    plugins: { 'react-hooks': reactHooks, '@typescript-eslint': tseslint.plugin },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "lint:hooks": "eslint . --config eslint.hooks.config.js",
     "preview": "vite preview",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -25,6 +25,21 @@ export default function ConfirmationModal({
 }: ConfirmationModalProps) {
   const { t } = useTranslation();
 
+  // Handle escape key. This must run before any early return so the hook order
+  // stays identical whether the modal is open or closed — toggling isOpen after
+  // an early `return null` would change the hook count and crash with React
+  // error #310 ("Rendered more hooks than during the previous render").
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen, onClose]);
+
   if (!isOpen) return null;
 
   const finalConfirmText = confirmText || t('common.confirm');
@@ -74,20 +89,6 @@ export default function ConfirmationModal({
   const handleCancel = () => {
     onClose();
   };
-
-  // Handle escape key
-  React.useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      return () => document.removeEventListener('keydown', handleEscape);
-    }
-  }, [isOpen, onClose]);
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">


### PR DESCRIPTION
## Summary

Fixes the production crash reported by a user (React error #310) when deleting a bulletin, and adds a CI gate so this class of bug can't ship again. Also carries the previously-committed interpreter-field change on this branch.

## The bug (`137928d`)

`ConfirmationModal` called its escape-key `useEffect` **after** an `if (!isOpen) return null` early return. A closed modal rendered 1 hook; an open one rendered 2. Toggling `isOpen` false→true threw **"Rendered more hooks than during the previous render" (#310)**.

This modal backs *every* confirm dialog in the app (delete bulletin, sign out, load bulletin, new bulletin), so each one crashed on open — and the error boundary then unmounted the editor, which is why unrelated things like reordering announcement sections also appeared broken.

**Fix:** move the `useEffect` above the early return so hook order is stable across renders. The effect already guards on `isOpen` internally, so behavior is unchanged.

## The gate (`3f2535a`)

The rule that catches this (`react-hooks/rules-of-hooks`) was configured but not enforced in CI, so the bug shipped. Added:

- `eslint.hooks.config.js` — scoped config enforcing **only** `react-hooks/rules-of-hooks`
- `npm run lint:hooks`
- `.github/workflows/lint-hooks.yml` — runs it on PRs and pushes to `main`

Scoped to a single rule because the full `eslint .` currently reports 300+ pre-existing style/type errors and can't gate merges yet. When that backlog is cleared, this can be replaced by the broader gate.

## Verification

- ESLint scan of the whole codebase: **0 `rules-of-hooks` violations** remaining (`ConfirmationModal` was the only one).
- Confirmed the scoped config passes on the current tree (exit 0) **and** flags the pre-fix `ConfirmationModal` with the exact #310 error (exit 1).
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)