### PR TITLE
Allow reordering whole announcement sections

### DIFF
--- a/src/components/BulletinForm.tsx
+++ b/src/components/BulletinForm.tsx
@@ -222,6 +222,40 @@ function BulletinForm({ data, onChange, profileSlug, userId, allImages: external
     return { first: gi === 0, last: gi === group.length - 1 };
   };
 
+  // The display order of the whole sections (RS, EQ, Youth, …) is the
+  // first-occurrence order of each audience in the flat array, matching how
+  // the form and preview both group with reduce()+Object.keys.
+  const groupOrder = (): string[] => {
+    const order: string[] = [];
+    for (const a of data.announcements) {
+      const key = a.audience || 'ward';
+      if (!order.includes(key)) order.push(key);
+    }
+    return order;
+  };
+
+  const sectionGroupPosition = (audience: string): { first: boolean; last: boolean } => {
+    const order = groupOrder();
+    const i = order.indexOf(audience);
+    return { first: i <= 0, last: i === order.length - 1 };
+  };
+
+  // Move an entire audience section up/down past its neighboring section.
+  // Rebuild the flat array following the swapped group order, keeping each
+  // section's internal item order intact — so section order changes while
+  // within-section order (and every other section) is preserved.
+  const moveSection = (audience: string, direction: -1 | 1) => {
+    const order = groupOrder();
+    const index = order.indexOf(audience);
+    const target = index + direction;
+    if (index === -1 || target < 0 || target >= order.length) return;
+    [order[index], order[target]] = [order[target], order[index]];
+    const updated = order.flatMap(key =>
+      data.announcements.filter(a => (a.audience || 'ward') === key)
+    );
+    updateField('announcements', updated);
+  };
+
           const handleRecurringAnnouncementSelected = (announcement: any) => {
           // Check if this is a standalone recurring announcement
           const isStandalone = announcement.audience === 'standalone';
@@ -1828,15 +1862,39 @@ function BulletinForm({ data, onChange, profileSlug, userId, allImages: external
                   : (audienceOptions.find(opt => opt.value === audience)?.label || getAudienceDisplayName(audience));
 
                 // Get the index of this group's first announcement in the full list for move operations
-                const groupFirstIndex = data.announcements.findIndex(a => a.audience === audience);
                 const allAudienceKeys = Object.keys(grouped);
-                const groupIndex = allAudienceKeys.indexOf(audience);
 
                 return (
                   <div key={audience} className="border border-gray-200 rounded-lg p-4 mb-4 bg-white">
                     {/* Type Header */}
                     <div className="flex items-center justify-between mb-4 pb-3 border-b border-gray-200">
                       <div className="flex items-center gap-3 flex-1">
+                        {/* Move the whole section up/down past its neighbor.
+                            Only meaningful when more than one section exists. */}
+                        {allAudienceKeys.length > 1 && (
+                          <div className="flex flex-col flex-shrink-0 -my-1">
+                            <button
+                              type="button"
+                              onClick={() => moveSection(audience, -1)}
+                              disabled={sectionGroupPosition(audience).first}
+                              title={t('form.moveSectionUp')}
+                              aria-label={t('form.moveSectionUp')}
+                              className="px-2 leading-none text-gray-500 hover:text-black disabled:opacity-30 disabled:hover:text-gray-500 transition-colors"
+                            >
+                              ▲
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => moveSection(audience, 1)}
+                              disabled={sectionGroupPosition(audience).last}
+                              title={t('form.moveSectionDown')}
+                              aria-label={t('form.moveSectionDown')}
+                              className="px-2 leading-none text-gray-500 hover:text-black disabled:opacity-30 disabled:hover:text-gray-500 transition-colors"
+                            >
+                              ▼
+                            </button>
+                          </div>
+                        )}
                         {isStandalone ? (
                           <input
                             type="text"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -412,6 +412,8 @@
     "xLarge": "Sehr Groß",
     "moveUp": "Nach oben verschieben",
     "moveDown": "Nach unten verschieben",
+    "moveSectionUp": "Abschnitt nach oben verschieben",
+    "moveSectionDown": "Abschnitt nach unten verschieben",
     "orChooseFromExisting": "oder aus vorhandenen auswählen",
     "consolidate": "Zusammenfassen",
     "consolidateTooltip": "Gruppiert mehrere Ankündigungen nach Zielgruppe in zusammengefasste Einträge.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -412,6 +412,8 @@
     "xLarge": "X-Large",
     "moveUp": "Move up",
     "moveDown": "Move down",
+    "moveSectionUp": "Move section up",
+    "moveSectionDown": "Move section down",
     "orChooseFromExisting": "Or choose from existing images",
     "consolidate": "Consolidate",
     "consolidateTooltip": "Group multiple announcements by their target audience into single consolidated entries.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -438,6 +438,8 @@
     "xLarge": "Extra Grande",
     "moveUp": "Mover arriba",
     "moveDown": "Mover abajo",
+    "moveSectionUp": "Mover sección arriba",
+    "moveSectionDown": "Mover sección abajo",
     "orChooseFromExisting": "o elegir de existentes",
     "consolidate": "Consolidar",
     "consolidateTooltip": "Agrupa múltiples anuncios en entradas consolidadas por audiencia objetivo.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -438,6 +438,8 @@
     "xLarge": "Très Grand",
     "moveUp": "Déplacer vers le haut",
     "moveDown": "Déplacer vers le bas",
+    "moveSectionUp": "Déplacer la section vers le haut",
+    "moveSectionDown": "Déplacer la section vers le bas",
     "orChooseFromExisting": "ou choisir parmi les existants",
     "consolidate": "Consolider",
     "consolidateTooltip": "Regroupe plusieurs annonces en entrées consolidées par public cible.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -412,6 +412,8 @@
     "xLarge": "Extra Grande",
     "moveUp": "Sposta su",
     "moveDown": "Sposta giù",
+    "moveSectionUp": "Sposta sezione su",
+    "moveSectionDown": "Sposta sezione giù",
     "orChooseFromExisting": "o scegli tra esistenti",
     "consolidate": "Consolida",
     "consolidateTooltip": "Raggruppa più annunci in voci consolidate per pubblico di destinazione.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -438,6 +438,8 @@
     "xLarge": "特大",
     "moveUp": "上に移動",
     "moveDown": "下に移動",
+    "moveSectionUp": "セクションを上に移動",
+    "moveSectionDown": "セクションを下に移動",
     "orChooseFromExisting": "または既存から選択",
     "consolidate": "統合",
     "consolidateTooltip": "複数のお知らせを対象者別に統合されたエントリにグループ化します。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -438,6 +438,8 @@
     "xLarge": "매우 큼",
     "moveUp": "위로 이동",
     "moveDown": "아래로 이동",
+    "moveSectionUp": "섹션 위로 이동",
+    "moveSectionDown": "섹션 아래로 이동",
     "orChooseFromExisting": "또는 기존 항목에서 선택",
     "consolidate": "통합",
     "consolidateTooltip": "여러 공지사항을 대상별로 통합된 항목으로 그룹화합니다.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -412,6 +412,8 @@
     "xLarge": "Extra Grande",
     "moveUp": "Mover para cima",
     "moveDown": "Mover para baixo",
+    "moveSectionUp": "Mover seção para cima",
+    "moveSectionDown": "Mover seção para baixo",
     "orChooseFromExisting": "Ou escolha de imagens existentes",
     "consolidate": "Consolidar",
     "consolidateTooltip": "Agrupe vários anúncios pelo público-alvo em entradas consolidadas.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -411,6 +411,8 @@
     "xLarge": "特大",
     "moveUp": "上移",
     "moveDown": "下移",
+    "moveSectionUp": "上移區段",
+    "moveSectionDown": "下移區段",
     "orChooseFromExisting": "或從現有圖片中選擇",
     "consolidate": "整合",
     "consolidateTooltip": "將多個公告按目標對象分組為整合條目。",


### PR DESCRIPTION
## Summary

Adds the ability to move entire announcement **sections** (Relief Society, Elders Quorum, Youth, standalone sections, …) up and down. Previously you could only reorder announcements *within* a section — the sections themselves were locked into first-occurrence order.

## What changed

- New **▲ / ▼ arrows** in each section header that move the whole section past its neighbor.
  - Shown only when there's more than one section; disabled at the top/bottom.
  - Standalone ("no grouping") sections get them too.
- The existing within-section up/down buttons are unchanged.

## How it works

Announcements are stored as one flat array where **section order = first-occurrence order** of each audience (the same rule the form and the public preview/print already use to group). `moveSection` swaps the target section with its neighbor in that order and rebuilds the flat array section-by-section, so:

- section order changes,
- each section's internal item order is preserved,
- every other section stays put.

Because the preview/print group by the same rule, they reflect the new order automatically.

## i18n

Adds `form.moveSectionUp` / `form.moveSectionDown` to all 9 locales (en, es, fr, de, it, pt, zh, ja, ko), matching each locale's existing move/section wording.

## Cleanup

Removed two dead leftover variables (`groupFirstIndex`, `groupIndex`) that were scaffolding for exactly this feature.

## Verification

- `tsc --noEmit` clean
- `vite build` succeeds
- All 9 locale JSON files validated
- Manually tested locally (dev server): moving sections reorders both the form and the live preview; within-section order preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)