### PR TITLE
Fix hymn #340 title: The Star-Spangled Banner

### DIFF
--- a/src/data/hymns.ts
+++ b/src/data/hymns.ts
@@ -339,7 +339,7 @@ export const LDS_HYMNS: Record<number, string> = {
   337: "O Home Beloved",
   338: "America the Beautiful",
   339: "My Country, 'Tis of Thee",
-  340: "Come, Come, Ye Saints",
+  340: "The Star-Spangled Banner",
   341: "God Save the King",
   
   // Sabbath and Weekday (1001–1041)


### PR DESCRIPTION
Hymn #340 was incorrectly labeled "Come, Come, Ye Saints" in the LDS
hymnal data, causing it to surface as a duplicate in the hymn-title
autocomplete and never resolve to the correct song. Verified against the
official Gospel Library hymnal (#338 America the Beautiful, #339 My
Country, 'Tis of Thee, #340 The Star-Spangled Banner, #341 God Save the
King). #326 (Come, Come, Ye Saints, Men's Choir) is a legitimate
arrangement and was left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETygBxFSA1q46NGoirPVv9